### PR TITLE
fix: 仪表盘支持自动刷新

### DIFF
--- a/frontend/src/composables/useAutoRefresh.ts
+++ b/frontend/src/composables/useAutoRefresh.ts
@@ -1,0 +1,49 @@
+export interface AutoRefreshOptions {
+  intervalMs: number
+  immediate?: boolean
+}
+
+export function useAutoRefresh(
+  refreshFn: () => Promise<unknown>,
+  options: AutoRefreshOptions
+) {
+  let timer: number | null = null
+  let inflight: Promise<unknown> | null = null
+
+  async function refresh(force = false) {
+    if (!force && document.visibilityState !== 'visible') return
+    if (inflight) return inflight
+    inflight = refreshFn().catch(() => undefined)
+    try {
+      await inflight
+    } finally {
+      inflight = null
+    }
+  }
+
+  function handleFocus() {
+    void refresh(true)
+  }
+
+  function handleVisibilityChange() {
+    if (document.visibilityState === 'visible') void refresh(true)
+  }
+
+  onMounted(() => {
+    window.addEventListener('focus', handleFocus)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    timer = window.setInterval(() => { void refresh() }, options.intervalMs)
+    if (options.immediate) void refresh(true)
+  })
+
+  onUnmounted(() => {
+    if (timer !== null) {
+      window.clearInterval(timer)
+      timer = null
+    }
+    window.removeEventListener('focus', handleFocus)
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
+  })
+
+  return { refresh }
+}

--- a/frontend/src/views/dashboard/index.vue
+++ b/frontend/src/views/dashboard/index.vue
@@ -96,16 +96,16 @@ import * as echarts from 'echarts/core'
 
 use([LineChart, BarChart, TooltipComponent, GridComponent, DatasetComponent, TransformComponent, LegendComponent, CanvasRenderer])
 
-import { useDashboardStore } from '@/stores/dashboard'
 import { useProviderStore } from '@/stores/providers'
 import { useSettingsStore } from '@/stores/settings'
 import { statsApi } from '@/api/stats'
 import { formatTokens } from '@/utils/json'
+import { useAutoRefresh } from '@/composables/useAutoRefresh'
 import type { ProviderStats, DailyStats } from '@/types/models'
 
-const dashboardStore = useDashboardStore()
 const providerStore = useProviderStore()
 const settingsStore = useSettingsStore()
+const DASHBOARD_REFRESH_INTERVAL_MS = 5_000
 
 const cliList = [
   { type: 'claude_code', label: 'Claude Code' },
@@ -211,6 +211,10 @@ async function fetchChartData() {
   dailyStats.value = dailyRes.data
 }
 
+useAutoRefresh(async () => {
+  await Promise.allSettled([fetchStats(), fetchChartData()])
+}, { intervalMs: DASHBOARD_REFRESH_INTERVAL_MS, immediate: true })
+
 const chartOption = computed(() => {
   const dates: string[] = []
   for (let i = 6; i >= 0; i--) {
@@ -284,14 +288,9 @@ const chartOption = computed(() => {
   }
 })
 
-onMounted(async () => {
-  await Promise.all([
-    dashboardStore.fetchStatus(),
-    providerStore.fetchProviders(),
-    settingsStore.fetchSettings(),
-    fetchStats(),
-    fetchChartData()
-  ])
+onMounted(() => {
+  void providerStore.fetchProviders()
+  void settingsStore.fetchSettings()
 })
 </script>
 


### PR DESCRIPTION
  ## 变更说明

  修复仪表盘页面统计数据不会实时刷新的问题。此前页面数据仅在首次进入时加载一次，停留在当前页面时不会自动更新，通常需要切换到其他页面再返回才能看到最新数据。

  本次改动将仪表盘统计刷新逻辑提取为可复用的自动刷新 composable，并在仪表盘页面中启用定时刷新与窗口激活刷新。

  ## 主要改动

  - 新增 `useAutoRefresh` composable
  - 仪表盘页面每 5 秒自动刷新一次统计数据
  - 页面在窗口重新获得焦点、或从后台切回前台时立即刷新
  - 增加并发保护，避免上一次刷新未完成时重复发起请求
  - 保持页面不可见时不执行常规定时刷新，减少无意义请求