### PR TITLE
fix: 修复非 Windows 平台插件命令执行失败

### DIFF
--- a/src-tauri/src/services/plugin.rs
+++ b/src-tauri/src/services/plugin.rs
@@ -28,22 +28,29 @@ pub struct FavoriteInstallResult {
 
 /// 执行 claude 命令，返回完整输出
 fn run_claude(args: &[&str]) -> Result<String> {
-    let args_str = args
-        .iter()
-        .map(|s| {
-            if s.contains(' ') || s.contains('"') {
-                format!("\"{}\"", s.replace('"', "\\\""))
-            } else {
-                s.to_string()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ");
+    #[cfg(windows)]
+    let output = {
+        let args_str = args
+            .iter()
+            .map(|s| {
+                if s.contains(' ') || s.contains('"') {
+                    format!("\"{}\"", s.replace('"', "\\\""))
+                } else {
+                    s.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
 
-    let output = Command::new("cmd")
-        .args(["/c", &format!("claude {}", args_str)])
-        .output()
-        .map_err(|e| format!("执行命令遇到错误：{}", e))?;
+        Command::new("cmd")
+            .args(["/c", &format!("claude {}", args_str)])
+            .output()
+    };
+
+    #[cfg(not(windows))]
+    let output = Command::new("claude").args(args).output();
+
+    let output = output.map_err(|e| format!("执行命令遇到错误：{}", e))?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();


### PR DESCRIPTION
  ## 变更说明

  修复 Linux/macOS 等非 Windows 平台打开插件页面时报错的问题。此前插件管理命令统一通过 `cmd /c claude ...` 执行，非 Windows 环境没有 `cmd`，导致进入插件页面时加载已安装插件和收藏列表都会报 `No such file or directory (os error 2)`。

  本次改动保留 Windows 下原有的 `cmd /c` 调用方式，在非 Windows 平台直接执行 `claude` 命令并传入参数。

  ## 主要改动

  - Windows 平台继续使用 `cmd /c claude ...`
  - 非 Windows 平台改为直接调用 `claude` 可执行文件
  - 修复 Linux/macOS 下插件列表、收藏列表和插件市场操作因缺少 `cmd` 失败的问题
  - 保持现有 CLI 输出处理逻辑不变