### PR TITLE
fix: 修复 MCP 编辑后未同步本地配置

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2774,6 +2774,14 @@ pub async fn update_mcp(
     input: McpUpdate,
 ) -> Result<McpResponse> {
     let now = chrono::Utc::now().timestamp();
+    let cli_types = ["claude_code", "codex", "gemini"];
+
+    let current = sqlx::query_as::<_, McpConfig>("SELECT * FROM mcp_configs WHERE id = ?")
+        .bind(id)
+        .fetch_optional(db.inner())
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "MCP not found".to_string())?;
 
     // Validate JSON format if config_json is provided and not empty
     if let Some(ref config) = input.config_json {
@@ -2784,20 +2792,29 @@ pub async fn update_mcp(
         }
     }
 
-    let (name, config_json) = if input.name.is_some() || input.config_json.is_some() {
-        let current = sqlx::query_as::<_, McpConfig>("SELECT * FROM mcp_configs WHERE id = ?")
-            .bind(id)
-            .fetch_optional(db.inner())
-            .await
-            .map_err(|e| e.to_string())?
-            .ok_or_else(|| "MCP not found".to_string())?;
+    let current_cli_flags = {
+        let mut flags = Vec::new();
+        for cli_type in cli_types {
+            flags.push(McpCliFlag {
+                cli_type: cli_type.to_string(),
+                enabled: mcp_enabled_in_file_async(db.inner(), cli_type, &current.name).await,
+            });
+        }
+        flags
+    };
 
-        let new_name = input.name.unwrap_or(current.name.clone());
-        let new_config = input
-            .config_json
-            .map(|c| c.trim().to_string())
-            .unwrap_or(current.config_json.clone());
+    let new_name = input.name.unwrap_or_else(|| current.name.clone());
+    let new_config = input
+        .config_json
+        .map(|c| c.trim().to_string())
+        .unwrap_or_else(|| current.config_json.clone());
+    let cli_flags = input.cli_flags.unwrap_or(current_cli_flags);
 
+    if cli_flags.iter().any(|f| f.cli_type == "codex" && f.enabled) {
+        parse_codex_mcp_toml_table(&new_config)?;
+    }
+
+    if new_name != current.name || new_config != current.config_json {
         sqlx::query(
             "UPDATE mcp_configs SET name = ?, config_json = ?, updated_at = ? WHERE id = ?",
         )
@@ -2808,23 +2825,15 @@ pub async fn update_mcp(
         .execute(db.inner())
         .await
         .map_err(map_db_error)?;
-
-        (new_name, new_config)
-    } else {
-        // Get current values if not updating
-        let current = sqlx::query_as::<_, McpConfig>("SELECT * FROM mcp_configs WHERE id = ?")
-            .bind(id)
-            .fetch_optional(db.inner())
-            .await
-            .map_err(|e| e.to_string())?
-            .ok_or_else(|| "MCP not found".to_string())?;
-        (current.name, current.config_json)
-    };
-
-    // Sync to CLI files if cli_flags provided
-    if let Some(cli_flags) = input.cli_flags {
-        sync_single_mcp_to_cli(db.inner(), id, &name, &config_json, &cli_flags).await?;
     }
+
+    if new_name != current.name {
+        delete_mcp_from_cli(db.inner(), &current.name).await?;
+    }
+
+    // Keep already-enabled CLI config files in sync even when the frontend only
+    // submits name/config_json from the edit dialog.
+    sync_single_mcp_to_cli(db.inner(), id, &new_name, &new_config, &cli_flags).await?;
 
     get_mcp(db, id).await
 }


### PR DESCRIPTION
  ## 变更说明

  修复 MCP 编辑保存后本地 CLI 配置文件没有同步更新的问题。此前编辑弹窗保存时只提交 `name` 和 `config_json`，后端只有在请求携带 `cli_flags` 时才会同步写入 Claude Code、Codex、Gemini 的配置文件，导致界面提示更新成功，但已启用的本地 MCP 配置仍然保持旧内容。

  本次改动在更新 MCP 时会读取当前各 CLI 配置文件中的真实启用状态，并在数据库更新后将新配置同步到已启用的 CLI 配置文件中。如果 MCP 名称发生变化，也会清理旧名称下的本地配置，避免残留无效条目。

  ## 主要改动

  - 编辑 MCP 时自动读取 Claude Code、Codex、Gemini 中的现有启用状态
  - 即使前端未提交 `cli_flags`，也会把新配置同步到已启用的本地 CLI 配置文件
  - MCP 重命名时删除旧名称对应的本地配置条目
  - Codex MCP 已启用时提前校验配置能否转换为 TOML，避免本地写入失败后状态不一致
  - 保持手动切换 CLI 启用状态时的原有同步逻辑不变