### PR TITLE
fix: 修复 Codex 流式 Token 统计为 0

### DIFF
--- a/src-tauri/src/api/handlers.rs
+++ b/src-tauri/src/api/handlers.rs
@@ -367,7 +367,7 @@ fn parse_streaming_usage_chunk(
     cli_type: CliType,
     usage: &mut TokenUsage,
 ) {
-    const MAX_SSE_LINE_BUFFER: usize = 64 * 1024;
+    const MAX_SSE_LINE_BUFFER: usize = 1024 * 1024;
 
     buffer.push_str(&String::from_utf8_lossy(chunk));
     while let Some(pos) = buffer.find('\n') {
@@ -382,8 +382,12 @@ fn parse_streaming_usage_chunk(
     }
 
     if buffer.len() > MAX_SSE_LINE_BUFFER {
-        let drain_len = buffer.len() - MAX_SSE_LINE_BUFFER;
-        buffer.drain(..drain_len);
+        tracing::warn!(
+            "[{}] SSE line exceeded {} bytes before newline; dropping buffered line, token usage in this event may be missed",
+            cli_type,
+            MAX_SSE_LINE_BUFFER
+        );
+        buffer.clear();
     }
 }
 


### PR DESCRIPTION
  ## 变更说明

  修复 Codex 流式响应中 `response.completed` 事件较大时，Token 用量统计为 0 的问题。

  ## 主要改动

  - 将 SSE 单行缓冲上限从 64KB 调整为 1MiB，避免 Codex Responses API 的大 `response.completed` 行在解析前被截断
  - 超过缓冲上限时改为清空当前异常行并记录 warning，避免保留半截 JSON 导致后续解析混乱