### PR TITLE
feat: 增加启动和窗口行为设置

### DIFF
--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -32,6 +32,9 @@ export const settingsApi = {
         gateway: {
           debug_log: !!gateway.debug_log,
           log_detail_mode: gateway.log_detail_mode as 'full' | 'failure_only',
+          launch_on_startup: !!gateway.launch_on_startup,
+          silent_startup: !!gateway.silent_startup,
+          minimize_to_tray_on_close: !!gateway.minimize_to_tray_on_close,
         },
         timeouts,
         cli_settings: cliSettings,
@@ -43,6 +46,9 @@ export const settingsApi = {
     await invoke('update_gateway_settings', {
       debugLog: data.debug_log,
       logDetailMode: data.log_detail_mode,
+      launchOnStartup: data.launch_on_startup,
+      silentStartup: data.silent_startup,
+      minimizeToTrayOnClose: data.minimize_to_tray_on_close,
     })
     return { data: null }
   },

--- a/frontend/src/components/AppTitleBar.vue
+++ b/frontend/src/components/AppTitleBar.vue
@@ -1,0 +1,119 @@
+<template>
+  <div v-if="isLinux" class="app-titlebar">
+    <div class="titlebar-drag-region" @mousedown="startDrag" @dblclick="toggleMaximize">
+      <span class="titlebar-title">CCG Gateway</span>
+    </div>
+    <div class="titlebar-controls">
+      <button class="titlebar-button" type="button" title="最小化" @click="minimizeWindow">
+        <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M5 12h14" />
+        </svg>
+      </button>
+      <button class="titlebar-button" type="button" title="最大化" @click="toggleMaximize">
+        <svg width="13" height="13" viewBox="0 0 24 24" aria-hidden="true">
+          <rect x="5" y="5" width="14" height="14" rx="2" />
+        </svg>
+      </button>
+      <button class="titlebar-button close" type="button" title="关闭" @click="closeWindow">
+        <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M6 6l12 12M18 6L6 18" />
+        </svg>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { getCurrentWindow } from '@tauri-apps/api/window'
+
+const isLinux = /Linux/i.test(navigator.userAgent)
+const currentWindow = getCurrentWindow()
+
+function logWindowControlError(action: string, error: unknown) {
+  console.error(`Failed to ${action} window:`, error)
+}
+
+function minimizeWindow() {
+  currentWindow.minimize().catch((error) => logWindowControlError('minimize', error))
+}
+
+function toggleMaximize() {
+  currentWindow.toggleMaximize().catch((error) => logWindowControlError('toggle maximize', error))
+}
+
+function closeWindow() {
+  currentWindow.close().catch((error) => logWindowControlError('close', error))
+}
+
+function startDrag(event: MouseEvent) {
+  if (event.button !== 0 || event.detail > 1) return
+  currentWindow.startDragging().catch((error) => logWindowControlError('start dragging', error))
+}
+</script>
+
+<style scoped>
+.app-titlebar {
+  height: 34px;
+  display: flex;
+  align-items: center;
+  background: var(--color-bg-page);
+  border-bottom: 1px solid var(--color-border-light);
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.titlebar-drag-region {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding-left: 18px;
+  cursor: default;
+}
+
+.titlebar-title {
+  font-size: var(--fs-12);
+  font-weight: var(--fw-600);
+  color: var(--color-text-weak);
+}
+
+.titlebar-controls {
+  height: 100%;
+  display: flex;
+  align-items: stretch;
+}
+
+.titlebar-button {
+  width: 46px;
+  height: 100%;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  color: var(--color-text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+  transition: background-color 0.16s ease, color 0.16s ease;
+}
+
+.titlebar-button svg {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.titlebar-button:hover {
+  background: var(--color-overlay-8);
+  color: var(--color-text);
+}
+
+.titlebar-button.close:hover {
+  background: var(--color-danger);
+  color: #ffffff;
+}
+</style>

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,64 +1,67 @@
 <template>
-  <div class="app-shell">
-    <div class="sidebar">
-      <div class="logo">CCG Gateway</div>
-      
-      <div class="sidebar-scrollable">
-        <div class="nav-group">
-          <div class="nav-group-title">总览</div>
-          <div class="nav-item" :class="{ active: route.path === '/' }" @click="router.push('/')">仪表盘</div>
-          <div class="nav-item" :class="{ active: route.path === '/config' }" @click="router.push('/config')">全局设置</div>
-          <div class="nav-item" :class="{ active: route.path === '/logs' }" @click="router.push('/logs')">日志记录</div>
-          <div class="nav-item" :class="{ active: route.path === '/scheduled-tasks' }" @click="router.push('/scheduled-tasks')">定时任务</div>
-          <div class="nav-item" :class="{ active: route.path === '/sessions' }" @click="router.push('/sessions')">会话记录</div>
-        </div>
-        
-        <div class="nav-group">
-          <div class="nav-group-title">配置</div>
-          <!-- Note: Made the original menu paths consistent with old code, keeping '服务商管理' instead of '服务商' to match perfectly if desired, but spec says '服务商'. I'll stick to simple '服务商' -->
-          <div class="nav-item" :class="{ active: route.path === '/providers' }" @click="router.push('/providers')">服务商</div>
-          <div class="nav-item" :class="{ active: route.path === '/mcp' }" @click="router.push('/mcp')">MCP</div>
-          <div class="nav-item" :class="{ active: route.path === '/prompts' }" @click="router.push('/prompts')">提示词</div>
-          <div class="nav-item" :class="{ active: route.path === '/skills' }" @click="router.push('/skills')">Skill</div>
-          <div class="nav-item" :class="{ active: route.path === '/plugins' }" @click="router.push('/plugins')">Plugin</div>
-        </div>
-      </div>
-      
-      <div class="sidebar-footer">
-        <div class="footer-actions">
-          <button class="footer-btn" @click="themeStore.toggleTheme()" :title="themeStore.theme === 'light' ? '切换暗色' : '切换亮色'">
-            <svg v-if="themeStore.theme === 'light'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-            </svg>
-            <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
-            </svg>
-          </button>
-          <button class="footer-btn" @click="handleCheckUpdate" :disabled="checkingUpdate" title="检查更新">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" :class="{ 'spin': checkingUpdate }">
-              <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/>
-            </svg>
-          </button>
-          <button class="footer-btn" @click="toggleDevtools" title="开发者工具">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>
-            </svg>
-          </button>
-          <button class="footer-btn" @click="openGithubRepo" title="GitHub 仓库">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/>
-            </svg>
-          </button>
-        </div>
-        <div class="version-tag mono">
-          <span>v</span>{{ appVersion }}
-        </div>
-      </div>
-    </div>
+  <div class="root-shell">
+    <AppTitleBar />
+    <div class="app-shell">
+      <div class="sidebar">
+        <div class="logo">CCG Gateway</div>
 
-    <div class="view-container">
-      <div class="view-content">
-        <router-view />
+        <div class="sidebar-scrollable">
+          <div class="nav-group">
+            <div class="nav-group-title">总览</div>
+            <div class="nav-item" :class="{ active: route.path === '/' }" @click="router.push('/')">仪表盘</div>
+            <div class="nav-item" :class="{ active: route.path === '/config' }" @click="router.push('/config')">全局设置</div>
+            <div class="nav-item" :class="{ active: route.path === '/logs' }" @click="router.push('/logs')">日志记录</div>
+            <div class="nav-item" :class="{ active: route.path === '/scheduled-tasks' }" @click="router.push('/scheduled-tasks')">定时任务</div>
+            <div class="nav-item" :class="{ active: route.path === '/sessions' }" @click="router.push('/sessions')">会话记录</div>
+          </div>
+
+          <div class="nav-group">
+            <div class="nav-group-title">配置</div>
+            <!-- Note: Made the original menu paths consistent with old code, keeping '服务商管理' instead of '服务商' to match perfectly if desired, but spec says '服务商'. I'll stick to simple '服务商' -->
+            <div class="nav-item" :class="{ active: route.path === '/providers' }" @click="router.push('/providers')">服务商</div>
+            <div class="nav-item" :class="{ active: route.path === '/mcp' }" @click="router.push('/mcp')">MCP</div>
+            <div class="nav-item" :class="{ active: route.path === '/prompts' }" @click="router.push('/prompts')">提示词</div>
+            <div class="nav-item" :class="{ active: route.path === '/skills' }" @click="router.push('/skills')">Skill</div>
+            <div class="nav-item" :class="{ active: route.path === '/plugins' }" @click="router.push('/plugins')">Plugin</div>
+          </div>
+        </div>
+
+        <div class="sidebar-footer">
+          <div class="footer-actions">
+            <button class="footer-btn" @click="themeStore.toggleTheme()" :title="themeStore.theme === 'light' ? '切换暗色' : '切换亮色'">
+              <svg v-if="themeStore.theme === 'light'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+              </svg>
+              <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+              </svg>
+            </button>
+            <button class="footer-btn" @click="handleCheckUpdate" :disabled="checkingUpdate" title="检查更新">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" :class="{ 'spin': checkingUpdate }">
+                <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/>
+              </svg>
+            </button>
+            <button class="footer-btn" @click="toggleDevtools" title="开发者工具">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>
+              </svg>
+            </button>
+            <button class="footer-btn" @click="openGithubRepo" title="GitHub 仓库">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/>
+              </svg>
+            </button>
+          </div>
+          <div class="version-tag mono">
+            <span>v</span>{{ appVersion }}
+          </div>
+        </div>
+      </div>
+
+      <div class="view-container">
+        <div class="view-content">
+          <router-view />
+        </div>
       </div>
     </div>
   </div>
@@ -72,6 +75,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { checkForUpdates } from '@/utils/updater'
 import { open } from '@tauri-apps/plugin-shell'
 import { useThemeStore } from '@/stores/theme'
+import AppTitleBar from '@/components/AppTitleBar.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -108,7 +112,6 @@ onMounted(async () => {
 body {
   background: var(--color-bg-page);
   margin: 0;
-  padding: 20px;
   color: var(--color-text);
 }
 </style>
@@ -116,8 +119,16 @@ body {
 <style scoped>
 * { box-sizing: border-box; }
 
+.root-shell {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-page);
+  overflow: hidden;
+}
+
 .app-shell { 
-  display: flex; gap: 32px; height: calc(100vh - 40px); width: 100%;
+  display: flex; gap: 32px; flex: 1; min-height: 0; width: 100%; padding: 20px; overflow: hidden;
 }
 
 /* Sidebar Navigation */

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -194,11 +194,17 @@ export interface ScheduledTaskRunListResponse {
 export interface GatewaySettings {
   debug_log: boolean
   log_detail_mode: 'full' | 'failure_only'
+  launch_on_startup: boolean
+  silent_startup: boolean
+  minimize_to_tray_on_close: boolean
 }
 
 export interface GatewaySettingsRaw {
   debug_log: number
   log_detail_mode: string
+  launch_on_startup: number
+  silent_startup: number
+  minimize_to_tray_on_close: number
 }
 
 export interface TimeoutSettings {
@@ -239,6 +245,9 @@ export interface AllSettings {
 export interface GatewaySettingsUpdate {
   debug_log?: boolean
   log_detail_mode?: 'full' | 'failure_only'
+  launch_on_startup?: boolean
+  silent_startup?: boolean
+  minimize_to_tray_on_close?: boolean
 }
 
 export interface TimeoutSettingsUpdate {

--- a/frontend/src/utils/notification.ts
+++ b/frontend/src/utils/notification.ts
@@ -15,6 +15,7 @@ export function notify(message: string, type: NotifyType = 'success') {
     message,
     type,
     position: 'top-right',
+    offset: 48,
     duration: 2000
   })
 }

--- a/frontend/src/views/config/components/CliSettingsForm.vue
+++ b/frontend/src/views/config/components/CliSettingsForm.vue
@@ -209,7 +209,7 @@ defineExpose({ handleSave })
 .editor-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
 
 .f-textarea {
-  flex: 1; min-height: 240px; padding: 16px; border: 1px solid var(--color-border); border-radius: 12px;
+  flex: 1; min-height: 360px; padding: 16px; border: 1px solid var(--color-border); border-radius: 12px;
   font-size: var(--fs-14); background: var(--color-bg-page); color: var(--color-text); resize: none;
   outline: none; transition: all 0.2s; line-height: 1.6;
   word-break: break-all;

--- a/frontend/src/views/config/index.vue
+++ b/frontend/src/views/config/index.vue
@@ -63,11 +63,59 @@
         <!-- Right Column: Core & Backup -->
         <div class="config-column">
 
+          <!-- Basic Card -->
+          <div class="frost-card">
+            <div class="card-header-simple">
+              <svg width="20" height="20" class="header-icon"><use href="#icon-settings"/></svg>
+              <span class="card-label">基础配置</span>
+            </div>
+            <div class="card-body">
+              <div class="settings-toggles">
+                <label class="settings-toggle-item">
+                  <span class="settings-toggle-copy">
+                    <span class="settings-toggle-title">开机自启</span>
+                    <span class="settings-toggle-desc">登录系统后自动启动 CCG Gateway。</span>
+                  </span>
+                  <el-switch
+                    size="small"
+                    v-model="gatewayForm.launch_on_startup"
+                    :loading="gatewaySaving"
+                    @change="handleLaunchOnStartupChange"
+                  />
+                </label>
+                <label v-if="gatewayForm.launch_on_startup" class="settings-toggle-item">
+                  <span class="settings-toggle-copy">
+                    <span class="settings-toggle-title">静默启动</span>
+                    <span class="settings-toggle-desc">开机自启时不显示主窗口，仅在托盘运行。</span>
+                  </span>
+                  <el-switch
+                    size="small"
+                    v-model="gatewayForm.silent_startup"
+                    :loading="gatewaySaving"
+                    @change="handleGatewayToggleChange"
+                  />
+                </label>
+                <label class="settings-toggle-item">
+                  <span class="settings-toggle-copy">
+                    <span class="settings-toggle-title">关闭时最小化到托盘</span>
+                    <span class="settings-toggle-desc">点击窗口关闭按钮时隐藏窗口，应用继续在后台运行。</span>
+                  </span>
+                  <el-switch
+                    size="small"
+                    v-model="gatewayForm.minimize_to_tray_on_close"
+                    :loading="gatewaySaving"
+                    @change="handleGatewayToggleChange"
+                  />
+                </label>
+              </div>
+            </div>
+          </div>
+
           <!-- Timeout Card -->
           <div class="frost-card">
             <div class="card-header-simple">
               <svg width="20" height="20" class="header-icon"><use href="#icon-activity"/></svg>
-              <span class="card-label">基础配置</span>
+              <span class="card-label">请求超时</span>
               <div style="flex: 1;"></div>
               <button class="save-button" @click="saveTimeouts">
                 <svg width="16" height="16" style="margin-right: 6px;"><use href="#icon-save"/></svg>
@@ -232,20 +280,57 @@ const timeoutForm = ref({
   stream_idle_timeout: 60,
   non_stream_timeout: 120
 })
+const gatewayForm = ref({
+  launch_on_startup: false,
+  silent_startup: false,
+  minimize_to_tray_on_close: true
+})
+const gatewaySaving = ref(false)
 
 watch(() => settingsStore.settings, (settings) => {
   if (settings) {
     timeoutForm.value = { ...settings.timeouts }
+    gatewayForm.value = {
+      launch_on_startup: settings.gateway.launch_on_startup,
+      silent_startup: settings.gateway.silent_startup,
+      minimize_to_tray_on_close: settings.gateway.minimize_to_tray_on_close
+    }
   }
 }, { immediate: true })
 
 async function saveTimeouts() {
   try {
     await settingsStore.updateTimeouts(timeoutForm.value)
-    notify('超时配置已保存')
+    notify('请求超时已保存')
   } catch (e: any) {
     notify(getErrorMessage(e, '保存失败'), 'error')
   }
+}
+
+async function saveGateway() {
+  gatewaySaving.value = true
+  try {
+    if (!gatewayForm.value.launch_on_startup) {
+      gatewayForm.value.silent_startup = false
+    }
+    await settingsStore.updateGateway(gatewayForm.value)
+    notify('基础配置已保存')
+  } catch (e: any) {
+    notify(getErrorMessage(e, '保存失败'), 'error')
+  } finally {
+    gatewaySaving.value = false
+  }
+}
+
+async function handleLaunchOnStartupChange(value: string | number | boolean) {
+  const enabled = Boolean(value)
+  gatewayForm.value.launch_on_startup = enabled
+  gatewayForm.value.silent_startup = enabled
+  await saveGateway()
+}
+
+async function handleGatewayToggleChange() {
+  await saveGateway()
 }
 
 async function saveCli(cliType: CliType, data: any) {
@@ -415,7 +500,7 @@ onMounted(() => {
 .page-title { font-size: var(--fs-24); font-weight: var(--fw-700); color: var(--color-text); margin: 0 0 8px 0; letter-spacing: -0.8px; }
 
 /* Layout */
-.config-layout { display: flex; gap: 32px; align-items: flex-start; }
+.config-layout { display: flex; gap: 32px; align-items: stretch; }
 .config-column { flex: 1; display: flex; flex-direction: column; gap: 32px; min-width: 0; }
 
 /* Frost Card */
@@ -429,6 +514,24 @@ onMounted(() => {
 .header-icon { color: var(--color-text-muted); }
 .card-label { font-size: var(--fs-16); font-weight: var(--fw-600); letter-spacing: -0.3px; }
 
+.config-page :deep(.b-segmented) {
+  background: var(--color-bg-page);
+  border: 1px solid var(--color-border);
+  padding: 3px;
+}
+.config-page :deep(.b-seg-btn) {
+  border-radius: 7px;
+}
+.config-page :deep(.b-seg-btn:hover) {
+  color: var(--color-text-secondary);
+  background: var(--color-overlay-8);
+}
+.config-page :deep(.b-seg-btn.active) {
+  background: var(--color-primary-10);
+  color: var(--color-primary);
+  box-shadow: none;
+}
+
 /* Form Items */
 .input-item { margin-bottom: 20px; }
 .input-row { display: flex; gap: 16px; }
@@ -436,14 +539,35 @@ onMounted(() => {
 
 .input-with-unit { display: flex; align-items: center; gap: 12px; }
 .unit { font-size: var(--fs-14); color: var(--color-text-weak); font-weight: var(--fw-400); }
+.settings-toggles {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  background: var(--color-bg-page);
+  border-radius: 12px;
+  padding: 4px 16px;
+}
+.settings-toggle-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  min-height: 62px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--color-border-light);
+}
+.settings-toggle-item:last-child { border-bottom: none; }
+.settings-toggle-copy { min-width: 0; }
+.settings-toggle-title { display: block; font-size: var(--fs-14); font-weight: var(--fw-500); color: var(--color-text-secondary); }
+.settings-toggle-desc { display: block; margin-top: 4px; font-size: var(--fs-12); line-height: 1.4; color: var(--color-text-weak); }
 
 /* Buttons */
 .action-row-end { display: flex; justify-content: flex-end; gap: 12px; align-items: center; }
 .card-footer-right { margin-top: 8px; display: flex; justify-content: flex-end; }
 
 /* CLI Column adjustment */
-.cli-settings-card { flex: 1; }
-.cli-form-container { flex: 1; min-height: 400px; display: flex; flex-direction: column; }
+.cli-settings-card { flex: 1; min-height: 680px; }
+.cli-form-container { flex: 1; min-height: 520px; display: flex; flex-direction: column; }
 
 /* Flat Table (matching logs page style) */
 .table-container { background: var(--color-bg); border-radius: 12px; padding: 0; border: 1px solid var(--color-border); box-shadow: 0 4px 15px var(--color-shadow); overflow: hidden; }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -145,6 +145,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,11 +442,12 @@ name = "ccg-gateway"
 version = "1.8.4"
 dependencies = [
  "async-stream",
+ "auto-launch",
  "axum",
  "brotli",
  "bytes",
  "chrono",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http-body-util",
@@ -838,11 +850,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -853,7 +885,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -995,7 +1027,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -3188,6 +3220,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4355,7 +4398,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4405,7 +4448,7 @@ checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -5104,7 +5147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -6138,6 +6181,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -6256,7 +6308,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon", "devtools"] }
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
+auto-launch = "0.5"
 tokio = { version = "1", features = ["full"] }
 axum = "0.7"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,7 +5,11 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-close",
+    "core:window:allow-minimize",
     "core:window:allow-set-theme",
+    "core:window:allow-start-dragging",
+    "core:window:allow-toggle-maximize",
     "shell:default",
     "shell:allow-open",
     "dialog:default",

--- a/src-tauri/src/auto_launch.rs
+++ b/src-tauri/src/auto_launch.rs
@@ -1,0 +1,54 @@
+use ::auto_launch::{AutoLaunch, AutoLaunchBuilder};
+
+#[cfg(target_os = "macos")]
+fn get_macos_app_bundle_path(exe_path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let path_str = exe_path.to_string_lossy();
+    if let Some(app_pos) = path_str.find(".app/Contents/MacOS/") {
+        let app_bundle_end = app_pos + 4;
+        Some(std::path::PathBuf::from(&path_str[..app_bundle_end]))
+    } else {
+        None
+    }
+}
+
+fn get_auto_launch() -> Result<AutoLaunch, String> {
+    let exe_path = std::env::current_exe().map_err(|e| format!("无法获取应用路径: {e}"))?;
+
+    #[cfg(target_os = "macos")]
+    let app_path = get_macos_app_bundle_path(&exe_path).unwrap_or(exe_path);
+
+    #[cfg(not(target_os = "macos"))]
+    let app_path = exe_path;
+
+    AutoLaunchBuilder::new()
+        .set_app_name("CCG Gateway")
+        .set_app_path(&app_path.to_string_lossy())
+        .build()
+        .map_err(|e| format!("创建 AutoLaunch 失败: {e}"))
+}
+
+pub fn enable_auto_launch() -> Result<(), String> {
+    get_auto_launch()?
+        .enable()
+        .map_err(|e| format!("启用开机自启失败: {e}"))
+}
+
+pub fn disable_auto_launch() -> Result<(), String> {
+    get_auto_launch()?
+        .disable()
+        .map_err(|e| format!("禁用开机自启失败: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_bundle_path_is_detected() {
+        let exe_path =
+            std::path::Path::new("/Applications/CCG Gateway.app/Contents/MacOS/CCG Gateway");
+        assert_eq!(
+            super::get_macos_app_bundle_path(exe_path),
+            Some(std::path::PathBuf::from("/Applications/CCG Gateway.app"))
+        );
+    }
+}

--- a/src-tauri/src/commands/settings_commands.rs
+++ b/src-tauri/src/commands/settings_commands.rs
@@ -3,7 +3,7 @@ use super::*;
 #[tauri::command]
 pub async fn get_gateway_settings(db: State<'_, SqlitePool>) -> Result<GatewaySettings> {
     sqlx::query_as::<_, GatewaySettings>(
-        "SELECT debug_log, log_detail_mode FROM gateway_settings WHERE id = 1",
+        "SELECT debug_log, log_detail_mode, launch_on_startup, silent_startup, minimize_to_tray_on_close FROM gateway_settings WHERE id = 1",
     )
     .fetch_one(db.inner())
     .await
@@ -12,9 +12,13 @@ pub async fn get_gateway_settings(db: State<'_, SqlitePool>) -> Result<GatewaySe
 
 #[tauri::command]
 pub async fn update_gateway_settings(
+    app: tauri::AppHandle,
     db: State<'_, SqlitePool>,
     debug_log: Option<bool>,
     log_detail_mode: Option<String>,
+    launch_on_startup: Option<bool>,
+    silent_startup: Option<bool>,
+    minimize_to_tray_on_close: Option<bool>,
 ) -> Result<()> {
     let now = now_timestamp();
 
@@ -24,6 +28,15 @@ pub async fn update_gateway_settings(
     }
     if log_detail_mode.is_some() {
         updates.push("log_detail_mode = ?");
+    }
+    if launch_on_startup.is_some() {
+        updates.push("launch_on_startup = ?");
+    }
+    if silent_startup.is_some() {
+        updates.push("silent_startup = ?");
+    }
+    if minimize_to_tray_on_close.is_some() {
+        updates.push("minimize_to_tray_on_close = ?");
     }
     updates.push("updated_at = ?");
 
@@ -38,6 +51,21 @@ pub async fn update_gateway_settings(
     }
     if let Some(mode) = log_detail_mode {
         query = query.bind(mode);
+    }
+    if let Some(launch_on_startup) = launch_on_startup {
+        if launch_on_startup {
+            crate::auto_launch::enable_auto_launch()?;
+        } else {
+            crate::auto_launch::disable_auto_launch()?;
+        }
+        query = query.bind(if launch_on_startup { 1i64 } else { 0 });
+    }
+    if let Some(silent_startup) = silent_startup {
+        query = query.bind(if silent_startup { 1i64 } else { 0 });
+    }
+    if let Some(minimize_to_tray_on_close) = minimize_to_tray_on_close {
+        crate::set_minimize_to_tray_on_close(&app, minimize_to_tray_on_close);
+        query = query.bind(if minimize_to_tray_on_close { 1i64 } else { 0 });
     }
 
     query

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -213,7 +213,7 @@ async fn init_default_data(pool: &SqlitePool) -> Result<(), sqlx::Error> {
 
     // gateway_settings
     sqlx::query(
-        "INSERT OR IGNORE INTO gateway_settings (id, debug_log, updated_at) VALUES (1, 0, ?)",
+        "INSERT OR IGNORE INTO gateway_settings (id, debug_log, log_detail_mode, launch_on_startup, silent_startup, minimize_to_tray_on_close, updated_at) VALUES (1, 0, 'failure_only', 0, 0, 1, ?)",
     )
     .bind(now)
     .execute(pool)

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -337,6 +337,9 @@ pub struct GatewaySettingsRow {
     pub id: i64,
     pub debug_log: i64,
     pub log_detail_mode: String,
+    pub launch_on_startup: i64,
+    pub silent_startup: i64,
+    pub minimize_to_tray_on_close: i64,
     pub updated_at: i64,
 }
 
@@ -345,6 +348,9 @@ pub struct GatewaySettingsRow {
 pub struct GatewaySettings {
     pub debug_log: i64,
     pub log_detail_mode: String,
+    pub launch_on_startup: i64,
+    pub silent_startup: i64,
+    pub minimize_to_tray_on_close: i64,
 }
 
 // Timeout Settings (完整版 - 对应数据库表)

--- a/src-tauri/src/db/schema_definition.rs
+++ b/src-tauri/src/db/schema_definition.rs
@@ -97,7 +97,7 @@ impl DatabaseSchema {
     /// 获取当前主数据库 Schema
     pub fn current() -> Self {
         Self {
-            version: 27,
+            version: 28,
             tables: Self::define_main_tables(),
             indexes: Vec::new(),
         }
@@ -466,6 +466,24 @@ impl DatabaseSchema {
                         data_type: "TEXT".to_string(),
                         nullable: false,
                         default_value: Some("'failure_only'".to_string()),
+                    },
+                    ColumnDefinition {
+                        name: "launch_on_startup".to_string(),
+                        data_type: "INTEGER".to_string(),
+                        nullable: false,
+                        default_value: Some("0".to_string()),
+                    },
+                    ColumnDefinition {
+                        name: "silent_startup".to_string(),
+                        data_type: "INTEGER".to_string(),
+                        nullable: false,
+                        default_value: Some("0".to_string()),
+                    },
+                    ColumnDefinition {
+                        name: "minimize_to_tray_on_close".to_string(),
+                        data_type: "INTEGER".to_string(),
+                        nullable: false,
+                        default_value: Some("1".to_string()),
                     },
                     ColumnDefinition {
                         name: "updated_at".to_string(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod auto_launch;
 pub mod commands;
 pub mod config;
 pub mod db;
@@ -8,13 +9,69 @@ pub mod time;
 use config::Config;
 use db::{init_db, init_stats_db};
 use sqlx::SqlitePool;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
 use tauri::tray::{TrayIconBuilder, TrayIconEvent};
-use tauri::Manager;
+use tauri::{AppHandle, Manager, WebviewWindow};
 
 // Type wrappers for Tauri state
 pub struct LogDb(pub SqlitePool);
 pub struct StatsDb(pub SqlitePool);
+
+pub struct WindowBehaviorState {
+    minimize_to_tray_on_close: AtomicBool,
+    exit_requested: AtomicBool,
+}
+
+impl Default for WindowBehaviorState {
+    fn default() -> Self {
+        Self {
+            minimize_to_tray_on_close: AtomicBool::new(true),
+            exit_requested: AtomicBool::new(false),
+        }
+    }
+}
+
+impl WindowBehaviorState {
+    pub fn set_minimize_to_tray_on_close(&self, value: bool) {
+        self.minimize_to_tray_on_close
+            .store(value, Ordering::Relaxed);
+    }
+
+    pub fn minimize_to_tray_on_close(&self) -> bool {
+        self.minimize_to_tray_on_close.load(Ordering::Relaxed)
+    }
+
+    pub fn request_exit(&self) -> bool {
+        !self.exit_requested.swap(true, Ordering::SeqCst)
+    }
+}
+
+pub fn set_minimize_to_tray_on_close(app: &tauri::AppHandle, value: bool) {
+    app.state::<WindowBehaviorState>()
+        .set_minimize_to_tray_on_close(value);
+}
+
+fn show_main_window(window: &WebviewWindow) {
+    #[cfg(target_os = "windows")]
+    let _ = window.set_skip_taskbar(false);
+    let _ = window.show();
+    let _ = window.set_focus();
+    let _ = window.unminimize();
+}
+
+fn request_app_exit(app: &AppHandle) {
+    if !app.state::<WindowBehaviorState>().request_exit() {
+        return;
+    }
+
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        app.exit(0);
+    });
+}
 
 impl std::ops::Deref for LogDb {
     type Target = SqlitePool;
@@ -37,6 +94,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .manage(WindowBehaviorState::default())
         .setup(move |app| {
             let config = config.clone();
             app.manage(config.clone());
@@ -46,7 +104,7 @@ pub fn run() {
             let log_db_path = config.database.log_path.clone();
             let stats_db_path = config.database.stats_path.clone();
 
-            tauri::async_runtime::block_on(async {
+            let startup_settings = tauri::async_runtime::block_on(async {
                 // Ensure data directory exists
                 if let Some(parent) = db_path.parent() {
                     std::fs::create_dir_all(parent).ok();
@@ -77,6 +135,20 @@ pub fn run() {
                 app.manage(db.clone());
                 app.manage(LogDb(log_db.clone()));
                 app.manage(StatsDb(stats_db.clone()));
+
+                let startup_settings = sqlx::query_as::<_, db::models::GatewaySettings>(
+                    "SELECT debug_log, log_detail_mode, launch_on_startup, silent_startup, minimize_to_tray_on_close FROM gateway_settings WHERE id = 1",
+                )
+                .fetch_one(&db)
+                .await
+                .unwrap_or(db::models::GatewaySettings {
+                    debug_log: 0,
+                    log_detail_mode: "failure_only".to_string(),
+                    launch_on_startup: 0,
+                    silent_startup: 0,
+                    minimize_to_tray_on_close: 1,
+                });
+
                 let app_handle = app.handle().clone();
                 services::scheduler::start_scheduler(
                     db.clone(),
@@ -118,7 +190,12 @@ pub fn run() {
                         tracing::error!("Gateway server error: {}", e);
                     }
                 });
+
+                startup_settings
             });
+
+            app.state::<WindowBehaviorState>()
+                .set_minimize_to_tray_on_close(startup_settings.minimize_to_tray_on_close != 0);
 
             // Setup tray icon with menu
             let show_item = MenuItemBuilder::with_id("show", "显示窗口").build(app)?;
@@ -144,13 +221,11 @@ pub fn run() {
                 .on_menu_event(|app, event| match event.id().as_ref() {
                     "show" => {
                         if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.show();
-                            let _ = window.set_focus();
-                            let _ = window.unminimize();
+                            show_main_window(&window);
                         }
                     }
                     "quit" => {
-                        app.exit(0);
+                        request_app_exit(app);
                     }
                     _ => {}
                 })
@@ -164,11 +239,11 @@ pub fn run() {
                             match (window.is_visible(), window.is_minimized()) {
                                 (Ok(true), Ok(false)) => {
                                     let _ = window.hide();
+                                    #[cfg(target_os = "windows")]
+                                    let _ = window.set_skip_taskbar(true);
                                 }
                                 _ => {
-                                    let _ = window.show();
-                                    let _ = window.unminimize();
-                                    let _ = window.set_focus();
+                                    show_main_window(&window);
                                 }
                             }
                         }
@@ -177,13 +252,35 @@ pub fn run() {
                 })
                 .build(app)?;
 
-            // Handle window close event - always minimize to tray
+            // Apply startup visibility after creating the tray so silent startup remains reachable.
             if let Some(window) = app.get_webview_window("main") {
+                #[cfg(target_os = "linux")]
+                let _ = window.set_decorations(false);
+
+                if startup_settings.silent_startup != 0 {
+                    let _ = window.hide();
+                    #[cfg(target_os = "windows")]
+                    let _ = window.set_skip_taskbar(true);
+                } else {
+                    show_main_window(&window);
+                }
+            }
+
+            // Handle window close event according to the persisted window behavior setting.
+            if let Some(window) = app.get_webview_window("main") {
+                let app_handle = app.handle().clone();
                 let window_clone = window.clone();
                 window.on_window_event(move |event| {
                     if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                        let _ = window_clone.hide();
-                        api.prevent_close();
+                        if app_handle
+                            .state::<WindowBehaviorState>()
+                            .minimize_to_tray_on_close()
+                        {
+                            let _ = window_clone.hide();
+                            #[cfg(target_os = "windows")]
+                            let _ = window_clone.set_skip_taskbar(true);
+                            api.prevent_close();
+                        }
                     }
                 });
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,6 +16,7 @@
         "title": "CCG Gateway",
         "width": 1400,
         "height": 800,
+        "visible": false,
         "resizable": true,
         "fullscreen": false,
         "center": true,


### PR DESCRIPTION
## 变更说明

为全局设置增加启动与窗口行为相关配置，支持开机自启、静默启动以及关闭时最小化到托盘，并在 Linux 下提供应用内窗口控制按钮，避免无系统装饰窗口缺少最小化、最大化、关闭入口。

## 主要改动

- 新增开机自启、静默启动、关闭时最小化到托盘配置项
- 配置页拆分为基础配置、请求超时、备份与同步三个设置卡片
- 保存开机自启配置时同步更新系统自启动项
- 启动时根据静默启动配置决定是否显示主窗口
- 点击关闭按钮时根据配置隐藏到托盘或退出应用
- Linux 下隐藏系统窗口装饰并增加应用内标题栏窗口控制按钮
- 下移右上角通知提示，避免遮挡窗口控制按钮
