### PR TITLE
feat: 记住窗口尺寸和界面选择状态

### DIFF
--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -11,8 +11,13 @@ import type {
   SystemStatus,
   ProviderProfile,
   CliProfileSettingsStatus,
-  CliMode
+  CliMode,
+  UiTabSettingsUpdate
 } from '@/types/models'
+
+function normalizeCliType(value: string): CliType {
+  return (CLI_TYPES as readonly string[]).includes(value) ? value as CliType : 'claude_code'
+}
 
 export const settingsApi = {
   getAll: async () => {
@@ -35,6 +40,11 @@ export const settingsApi = {
           launch_on_startup: !!gateway.launch_on_startup,
           silent_startup: !!gateway.silent_startup,
           minimize_to_tray_on_close: !!gateway.minimize_to_tray_on_close,
+          window_width: gateway.window_width,
+          window_height: gateway.window_height,
+          config_active_cli_type: normalizeCliType(gateway.config_active_cli_type),
+          providers_active_cli_type: normalizeCliType(gateway.providers_active_cli_type),
+          sessions_active_cli_type: normalizeCliType(gateway.sessions_active_cli_type),
         },
         timeouts,
         cli_settings: cliSettings,
@@ -49,6 +59,14 @@ export const settingsApi = {
       launchOnStartup: data.launch_on_startup,
       silentStartup: data.silent_startup,
       minimizeToTrayOnClose: data.minimize_to_tray_on_close,
+    })
+    return { data: null }
+  },
+  updateUiTabs: async (data: UiTabSettingsUpdate) => {
+    await invoke('update_ui_tab_settings', {
+      configActiveCliType: data.config_active_cli_type,
+      providersActiveCliType: data.providers_active_cli_type,
+      sessionsActiveCliType: data.sessions_active_cli_type,
     })
     return { data: null }
   },

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { settingsApi } from '@/api/settings'
+import { useUiStore } from '@/stores/ui'
 import type { AllSettings, CliType, CliMode, GatewaySettingsUpdate, TimeoutSettingsUpdate, CliSettingsUpdate } from '@/types/models'
 
 export const useSettingsStore = defineStore('settings', () => {
@@ -12,6 +13,11 @@ export const useSettingsStore = defineStore('settings', () => {
     try {
       const { data } = await settingsApi.getAll()
       settings.value = data
+      useUiStore().applyPersistedTabs({
+        config_active_cli_type: data.gateway.config_active_cli_type,
+        providers_active_cli_type: data.gateway.providers_active_cli_type,
+        sessions_active_cli_type: data.gateway.sessions_active_cli_type
+      })
     } finally {
       loading.value = false
     }

--- a/frontend/src/stores/ui.ts
+++ b/frontend/src/stores/ui.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
+import { settingsApi } from '@/api/settings'
 import type { CliType, ProviderProfile } from '@/types/models'
 
 export const useUiStore = defineStore('ui', () => {
@@ -24,6 +25,9 @@ export const useUiStore = defineStore('ui', () => {
 
   function setProvidersActiveCliType(cliType: CliType) {
     providersActiveCliType.value = cliType
+    void settingsApi.updateUiTabs({ providers_active_cli_type: cliType }).catch((e) => {
+      console.error('Failed to persist providers active CLI tab:', e)
+    })
   }
 
   function getProvidersActiveProfile(cliType: CliType) {
@@ -36,6 +40,9 @@ export const useUiStore = defineStore('ui', () => {
 
   function setSessionsActiveCliType(cliType: CliType) {
     sessionsActiveCliType.value = cliType
+    void settingsApi.updateUiTabs({ sessions_active_cli_type: cliType }).catch((e) => {
+      console.error('Failed to persist sessions active CLI tab:', e)
+    })
   }
 
   function setLogsActiveTab(tab: 'request' | 'system') {
@@ -44,10 +51,29 @@ export const useUiStore = defineStore('ui', () => {
 
   function setConfigActiveCliTab(tab: CliType) {
     configActiveCliTab.value = tab
+    void settingsApi.updateUiTabs({ config_active_cli_type: tab }).catch((e) => {
+      console.error('Failed to persist config active CLI tab:', e)
+    })
   }
 
   function setConfigActiveBackupTab(tab: 'local' | 'webdav') {
     configActiveBackupTab.value = tab
+  }
+
+  function applyPersistedTabs(tabs: {
+    config_active_cli_type?: CliType
+    providers_active_cli_type?: CliType
+    sessions_active_cli_type?: CliType
+  }) {
+    if (tabs.config_active_cli_type) {
+      configActiveCliTab.value = tabs.config_active_cli_type
+    }
+    if (tabs.providers_active_cli_type) {
+      providersActiveCliType.value = tabs.providers_active_cli_type
+    }
+    if (tabs.sessions_active_cli_type) {
+      sessionsActiveCliType.value = tabs.sessions_active_cli_type
+    }
   }
 
   return {
@@ -64,5 +90,6 @@ export const useUiStore = defineStore('ui', () => {
     setLogsActiveTab,
     setConfigActiveCliTab,
     setConfigActiveBackupTab,
+    applyPersistedTabs,
   }
 })

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -197,6 +197,11 @@ export interface GatewaySettings {
   launch_on_startup: boolean
   silent_startup: boolean
   minimize_to_tray_on_close: boolean
+  window_width: number
+  window_height: number
+  config_active_cli_type: CliType
+  providers_active_cli_type: CliType
+  sessions_active_cli_type: CliType
 }
 
 export interface GatewaySettingsRaw {
@@ -205,6 +210,11 @@ export interface GatewaySettingsRaw {
   launch_on_startup: number
   silent_startup: number
   minimize_to_tray_on_close: number
+  window_width: number
+  window_height: number
+  config_active_cli_type: string
+  providers_active_cli_type: string
+  sessions_active_cli_type: string
 }
 
 export interface TimeoutSettings {
@@ -248,6 +258,12 @@ export interface GatewaySettingsUpdate {
   launch_on_startup?: boolean
   silent_startup?: boolean
   minimize_to_tray_on_close?: boolean
+}
+
+export interface UiTabSettingsUpdate {
+  config_active_cli_type?: CliType
+  providers_active_cli_type?: CliType
+  sessions_active_cli_type?: CliType
 }
 
 export interface TimeoutSettingsUpdate {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1678,6 +1678,73 @@ async fn write_provider_direct_config_with_previous(
             write_gemini_provider_direct_config(db, provider, previous_default_config).await
         }
         _ => Err("不支持的 CLI 类型".to_string()),
+    }?;
+
+    remember_provider_direct_write(db, provider).await?;
+    Ok(())
+}
+
+async fn remember_provider_direct_write(db: &SqlitePool, provider: &Provider) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO provider_direct_write_state (cli_type, profile, provider_id, updated_at)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(cli_type, profile) DO UPDATE SET provider_id = excluded.provider_id, updated_at = excluded.updated_at",
+    )
+    .bind(&provider.cli_type)
+    .bind(&provider.profile)
+    .bind(provider.id)
+    .bind(now_timestamp())
+    .execute(db)
+    .await
+    .map_err(map_db_error)?;
+
+    Ok(())
+}
+
+async fn clear_provider_direct_write_state(db: &SqlitePool, provider_id: i64) -> Result<()> {
+    sqlx::query("DELETE FROM provider_direct_write_state WHERE provider_id = ?")
+        .bind(provider_id)
+        .execute(db)
+        .await
+        .map_err(map_db_error)?;
+
+    Ok(())
+}
+
+async fn remembered_provider_direct_active_provider_id(
+    db: &SqlitePool,
+    cli_type: &str,
+    profile: &str,
+) -> Result<Option<i64>> {
+    let profile = validate_provider_profile(Some(profile))?;
+    let row: Option<(i64,)> = sqlx::query_as(
+        "SELECT s.provider_id
+         FROM provider_direct_write_state s
+         JOIN providers p ON p.id = s.provider_id
+         WHERE s.cli_type = ? AND s.profile = ? AND p.cli_type = ? AND p.profile = ?
+         LIMIT 1",
+    )
+    .bind(cli_type)
+    .bind(profile)
+    .bind(cli_type)
+    .bind(profile)
+    .fetch_optional(db)
+    .await
+    .map_err(map_db_error)?;
+
+    Ok(row.map(|(provider_id,)| provider_id))
+}
+
+async fn detected_provider_direct_active_provider_id(
+    db: &SqlitePool,
+    cli_type: &str,
+    profile: &str,
+) -> Result<Option<i64>> {
+    match cli_type {
+        "claude_code" => claude_provider_direct_active_provider_id(db, profile).await,
+        "codex" => codex_provider_direct_active_provider_id(db, profile).await,
+        "gemini" => gemini_provider_direct_active_provider_id(db).await,
+        _ => Ok(None),
     }
 }
 
@@ -1819,12 +1886,13 @@ async fn provider_direct_active_provider_id(
     cli_type: &str,
     profile: &str,
 ) -> Result<Option<i64>> {
-    match cli_type {
-        "claude_code" => claude_provider_direct_active_provider_id(db, profile).await,
-        "codex" => codex_provider_direct_active_provider_id(db, profile).await,
-        "gemini" => gemini_provider_direct_active_provider_id(db).await,
-        _ => Ok(None),
+    if let Some(provider_id) =
+        remembered_provider_direct_active_provider_id(db, cli_type, profile).await?
+    {
+        return Ok(Some(provider_id));
     }
+
+    detected_provider_direct_active_provider_id(db, cli_type, profile).await
 }
 
 async fn remove_codex_provider_direct_config_content(config_path: &std::path::Path) -> Result<()> {

--- a/src-tauri/src/commands/credential_commands.rs
+++ b/src-tauri/src/commands/credential_commands.rs
@@ -957,6 +957,29 @@ pub async fn write_credential_config(
 }
 
 async fn first_default_provider(db: &SqlitePool, cli_type: &str) -> Result<Provider> {
+    if let Some(provider_id) =
+        remembered_provider_direct_active_provider_id(db, cli_type, DEFAULT_PROFILE).await?
+    {
+        if let Some(provider) = sqlx::query_as::<_, Provider>(
+            "SELECT * FROM providers WHERE id = ? AND cli_type = ? AND profile = ?",
+        )
+        .bind(provider_id)
+        .bind(cli_type)
+        .bind(DEFAULT_PROFILE)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| e.to_string())?
+        {
+            if provider.base_url.trim().is_empty() || provider.api_key.trim().is_empty() {
+                return Err(format!(
+                    "服务商 {} 的 Base URL 或 API Key 为空",
+                    provider.name
+                ));
+            }
+            return Ok(provider);
+        }
+    }
+
     let provider: Provider = sqlx::query_as(
         "SELECT * FROM providers WHERE cli_type = ? AND profile = ? ORDER BY sort_order, id LIMIT 1",
     )

--- a/src-tauri/src/commands/provider_commands.rs
+++ b/src-tauri/src/commands/provider_commands.rs
@@ -605,6 +605,8 @@ pub async fn delete_provider(
         .await
         .map_err(map_db_error)?;
 
+    clear_provider_direct_write_state(db.inner(), id).await?;
+
     // Then delete the provider
     sqlx::query("DELETE FROM providers WHERE id = ?")
         .bind(id)

--- a/src-tauri/src/commands/settings_commands.rs
+++ b/src-tauri/src/commands/settings_commands.rs
@@ -3,11 +3,18 @@ use super::*;
 #[tauri::command]
 pub async fn get_gateway_settings(db: State<'_, SqlitePool>) -> Result<GatewaySettings> {
     sqlx::query_as::<_, GatewaySettings>(
-        "SELECT debug_log, log_detail_mode, launch_on_startup, silent_startup, minimize_to_tray_on_close FROM gateway_settings WHERE id = 1",
+        "SELECT debug_log, log_detail_mode, launch_on_startup, silent_startup, minimize_to_tray_on_close, window_width, window_height, config_active_cli_type, providers_active_cli_type, sessions_active_cli_type FROM gateway_settings WHERE id = 1",
     )
     .fetch_one(db.inner())
     .await
     .map_err(|e| e.to_string())
+}
+
+fn validate_cli_tab(cli_type: &str) -> Result<()> {
+    match cli_type {
+        "claude_code" | "codex" | "gemini" => Ok(()),
+        _ => Err(format!("未知 CLI 类型: {}", cli_type)),
+    }
 }
 
 #[tauri::command]
@@ -70,6 +77,57 @@ pub async fn update_gateway_settings(
 
     query
         .bind(now)
+        .execute(db.inner())
+        .await
+        .map_err(map_db_error)?;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn update_ui_tab_settings(
+    db: State<'_, SqlitePool>,
+    config_active_cli_type: Option<String>,
+    providers_active_cli_type: Option<String>,
+    sessions_active_cli_type: Option<String>,
+) -> Result<()> {
+    let mut updates = Vec::new();
+    if let Some(ref cli_type) = config_active_cli_type {
+        validate_cli_tab(cli_type)?;
+        updates.push("config_active_cli_type = ?");
+    }
+    if let Some(ref cli_type) = providers_active_cli_type {
+        validate_cli_tab(cli_type)?;
+        updates.push("providers_active_cli_type = ?");
+    }
+    if let Some(ref cli_type) = sessions_active_cli_type {
+        validate_cli_tab(cli_type)?;
+        updates.push("sessions_active_cli_type = ?");
+    }
+
+    if updates.is_empty() {
+        return Ok(());
+    }
+
+    updates.push("updated_at = ?");
+    let sql = format!(
+        "UPDATE gateway_settings SET {} WHERE id = 1",
+        updates.join(", ")
+    );
+    let mut query = sqlx::query(&sql);
+
+    if let Some(cli_type) = config_active_cli_type {
+        query = query.bind(cli_type);
+    }
+    if let Some(cli_type) = providers_active_cli_type {
+        query = query.bind(cli_type);
+    }
+    if let Some(cli_type) = sessions_active_cli_type {
+        query = query.bind(cli_type);
+    }
+
+    query
+        .bind(now_timestamp())
         .execute(db.inner())
         .await
         .map_err(map_db_error)?;

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -213,7 +213,7 @@ async fn init_default_data(pool: &SqlitePool) -> Result<(), sqlx::Error> {
 
     // gateway_settings
     sqlx::query(
-        "INSERT OR IGNORE INTO gateway_settings (id, debug_log, log_detail_mode, launch_on_startup, silent_startup, minimize_to_tray_on_close, updated_at) VALUES (1, 0, 'failure_only', 0, 0, 1, ?)",
+        "INSERT OR IGNORE INTO gateway_settings (id, debug_log, log_detail_mode, launch_on_startup, silent_startup, minimize_to_tray_on_close, window_width, window_height, config_active_cli_type, providers_active_cli_type, sessions_active_cli_type, updated_at) VALUES (1, 0, 'failure_only', 0, 0, 1, 1400, 850, 'claude_code', 'claude_code', 'claude_code', ?)",
     )
     .bind(now)
     .execute(pool)

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -340,6 +340,11 @@ pub struct GatewaySettingsRow {
     pub launch_on_startup: i64,
     pub silent_startup: i64,
     pub minimize_to_tray_on_close: i64,
+    pub window_width: i64,
+    pub window_height: i64,
+    pub config_active_cli_type: String,
+    pub providers_active_cli_type: String,
+    pub sessions_active_cli_type: String,
     pub updated_at: i64,
 }
 
@@ -351,6 +356,11 @@ pub struct GatewaySettings {
     pub launch_on_startup: i64,
     pub silent_startup: i64,
     pub minimize_to_tray_on_close: i64,
+    pub window_width: i64,
+    pub window_height: i64,
+    pub config_active_cli_type: String,
+    pub providers_active_cli_type: String,
+    pub sessions_active_cli_type: String,
 }
 
 // Timeout Settings (完整版 - 对应数据库表)

--- a/src-tauri/src/db/schema_definition.rs
+++ b/src-tauri/src/db/schema_definition.rs
@@ -97,7 +97,7 @@ impl DatabaseSchema {
     /// 获取当前主数据库 Schema
     pub fn current() -> Self {
         Self {
-            version: 28,
+            version: 29,
             tables: Self::define_main_tables(),
             indexes: Vec::new(),
         }
@@ -335,6 +335,42 @@ impl DatabaseSchema {
             },
         );
 
+        // provider_direct_write_state 表
+        tables.insert(
+            "provider_direct_write_state".to_string(),
+            TableDefinition {
+                name: "provider_direct_write_state".to_string(),
+                columns: vec![
+                    ColumnDefinition {
+                        name: "cli_type".to_string(),
+                        data_type: "TEXT".to_string(),
+                        nullable: false,
+                        default_value: None,
+                    },
+                    ColumnDefinition {
+                        name: "profile".to_string(),
+                        data_type: "TEXT".to_string(),
+                        nullable: false,
+                        default_value: None,
+                    },
+                    ColumnDefinition {
+                        name: "provider_id".to_string(),
+                        data_type: "INTEGER".to_string(),
+                        nullable: false,
+                        default_value: None,
+                    },
+                    ColumnDefinition {
+                        name: "updated_at".to_string(),
+                        data_type: "INTEGER".to_string(),
+                        nullable: false,
+                        default_value: None,
+                    },
+                ],
+                primary_key: vec!["cli_type".to_string(), "profile".to_string()],
+                unique_constraints: vec![],
+            },
+        );
+
         // scheduled_tasks 表
         tables.insert(
             "scheduled_tasks".to_string(),
@@ -484,6 +520,36 @@ impl DatabaseSchema {
                         data_type: "INTEGER".to_string(),
                         nullable: false,
                         default_value: Some("1".to_string()),
+                    },
+                    ColumnDefinition {
+                        name: "window_width".to_string(),
+                        data_type: "INTEGER".to_string(),
+                        nullable: false,
+                        default_value: Some("1400".to_string()),
+                    },
+                    ColumnDefinition {
+                        name: "window_height".to_string(),
+                        data_type: "INTEGER".to_string(),
+                        nullable: false,
+                        default_value: Some("850".to_string()),
+                    },
+                    ColumnDefinition {
+                        name: "config_active_cli_type".to_string(),
+                        data_type: "TEXT".to_string(),
+                        nullable: false,
+                        default_value: Some("'claude_code'".to_string()),
+                    },
+                    ColumnDefinition {
+                        name: "providers_active_cli_type".to_string(),
+                        data_type: "TEXT".to_string(),
+                        nullable: false,
+                        default_value: Some("'claude_code'".to_string()),
+                    },
+                    ColumnDefinition {
+                        name: "sessions_active_cli_type".to_string(),
+                        data_type: "TEXT".to_string(),
+                        nullable: false,
+                        default_value: Some("'claude_code'".to_string()),
                     },
                     ColumnDefinition {
                         name: "updated_at".to_string(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,11 +9,12 @@ pub mod time;
 use config::Config;
 use db::{init_db, init_stats_db};
 use sqlx::SqlitePool;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
 use tauri::tray::{TrayIconBuilder, TrayIconEvent};
-use tauri::{AppHandle, Manager, WebviewWindow};
+use tauri::{AppHandle, LogicalSize, Manager, Size, WebviewWindow};
 
 // Type wrappers for Tauri state
 pub struct LogDb(pub SqlitePool);
@@ -23,6 +24,9 @@ pub struct WindowBehaviorState {
     minimize_to_tray_on_close: AtomicBool,
     exit_requested: AtomicBool,
 }
+
+const DEFAULT_WINDOW_WIDTH: i64 = 1400;
+const DEFAULT_WINDOW_HEIGHT: i64 = 850;
 
 impl Default for WindowBehaviorState {
     fn default() -> Self {
@@ -59,6 +63,49 @@ fn show_main_window(window: &WebviewWindow) {
     let _ = window.show();
     let _ = window.set_focus();
     let _ = window.unminimize();
+}
+
+fn restore_window_size(window: &WebviewWindow, width: i64, height: i64) {
+    let width = if width > 0 {
+        width
+    } else {
+        DEFAULT_WINDOW_WIDTH
+    };
+    let height = if height > 0 {
+        height
+    } else {
+        DEFAULT_WINDOW_HEIGHT
+    };
+
+    let _ = window.set_size(Size::Logical(LogicalSize::new(width as f64, height as f64)));
+}
+
+fn save_window_size_later(
+    db: SqlitePool,
+    save_seq: Arc<AtomicU64>,
+    seq: u64,
+    width: i64,
+    height: i64,
+) {
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        if save_seq.load(Ordering::Relaxed) != seq {
+            return;
+        }
+
+        let result = sqlx::query(
+            "UPDATE gateway_settings SET window_width = ?, window_height = ?, updated_at = ? WHERE id = 1",
+        )
+        .bind(width)
+        .bind(height)
+        .bind(crate::time::now_timestamp())
+        .execute(&db)
+        .await;
+
+        if let Err(e) = result {
+            tracing::error!("Failed to save window size: {}", e);
+        }
+    });
 }
 
 fn request_app_exit(app: &AppHandle) {
@@ -137,7 +184,7 @@ pub fn run() {
                 app.manage(StatsDb(stats_db.clone()));
 
                 let startup_settings = sqlx::query_as::<_, db::models::GatewaySettings>(
-                    "SELECT debug_log, log_detail_mode, launch_on_startup, silent_startup, minimize_to_tray_on_close FROM gateway_settings WHERE id = 1",
+                    "SELECT debug_log, log_detail_mode, launch_on_startup, silent_startup, minimize_to_tray_on_close, window_width, window_height, config_active_cli_type, providers_active_cli_type, sessions_active_cli_type FROM gateway_settings WHERE id = 1",
                 )
                 .fetch_one(&db)
                 .await
@@ -147,6 +194,11 @@ pub fn run() {
                     launch_on_startup: 0,
                     silent_startup: 0,
                     minimize_to_tray_on_close: 1,
+                    window_width: DEFAULT_WINDOW_WIDTH,
+                    window_height: DEFAULT_WINDOW_HEIGHT,
+                    config_active_cli_type: "claude_code".to_string(),
+                    providers_active_cli_type: "claude_code".to_string(),
+                    sessions_active_cli_type: "claude_code".to_string(),
                 });
 
                 let app_handle = app.handle().clone();
@@ -217,7 +269,6 @@ pub fn run() {
                 .icon(icon)
                 .tooltip("CCG Gateway")
                 .menu(&menu)
-                .show_menu_on_left_click(false)
                 .on_menu_event(|app, event| match event.id().as_ref() {
                     "show" => {
                         if let Some(window) = app.get_webview_window("main") {
@@ -257,6 +308,12 @@ pub fn run() {
                 #[cfg(target_os = "linux")]
                 let _ = window.set_decorations(false);
 
+                restore_window_size(
+                    &window,
+                    startup_settings.window_width,
+                    startup_settings.window_height,
+                );
+
                 if startup_settings.silent_startup != 0 {
                     let _ = window.hide();
                     #[cfg(target_os = "windows")]
@@ -269,18 +326,37 @@ pub fn run() {
             // Handle window close event according to the persisted window behavior setting.
             if let Some(window) = app.get_webview_window("main") {
                 let app_handle = app.handle().clone();
+                let db = app.state::<SqlitePool>().inner().clone();
+                let resize_save_seq = Arc::new(AtomicU64::new(0));
                 let window_clone = window.clone();
                 window.on_window_event(move |event| {
-                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                        if app_handle
-                            .state::<WindowBehaviorState>()
-                            .minimize_to_tray_on_close()
-                        {
-                            let _ = window_clone.hide();
-                            #[cfg(target_os = "windows")]
-                            let _ = window_clone.set_skip_taskbar(true);
-                            api.prevent_close();
+                    match event {
+                        tauri::WindowEvent::CloseRequested { api, .. } => {
+                            if app_handle
+                                .state::<WindowBehaviorState>()
+                                .minimize_to_tray_on_close()
+                            {
+                                let _ = window_clone.hide();
+                                #[cfg(target_os = "windows")]
+                                let _ = window_clone.set_skip_taskbar(true);
+                                api.prevent_close();
+                            }
                         }
+                        tauri::WindowEvent::Resized(size) => {
+                            let scale_factor = window_clone.scale_factor().unwrap_or(1.0);
+                            let logical_size = size.to_logical::<f64>(scale_factor);
+                            let width = logical_size.width.round() as i64;
+                            let height = logical_size.height.round() as i64;
+                            let seq = resize_save_seq.fetch_add(1, Ordering::Relaxed) + 1;
+                            save_window_size_later(
+                                db.clone(),
+                                resize_save_seq.clone(),
+                                seq,
+                                width,
+                                height,
+                            );
+                        }
+                        _ => {}
                     }
                 });
             }
@@ -307,6 +383,7 @@ pub fn run() {
             commands::scheduled_task_commands::get_scheduled_task_run_items,
             commands::settings_commands::get_gateway_settings,
             commands::settings_commands::update_gateway_settings,
+            commands::settings_commands::update_ui_tab_settings,
             commands::settings_commands::get_timeout_settings,
             commands::settings_commands::update_timeout_settings,
             commands::settings_commands::get_cli_settings,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,7 @@
       {
         "title": "CCG Gateway",
         "width": 1400,
-        "height": 800,
+        "height": 850,
         "visible": false,
         "resizable": true,
         "fullscreen": false,


### PR DESCRIPTION
## 变更说明

持久化窗口尺寸、页面 CLI 选择状态以及中转直连最后写入的服务商，减少重启或切换模式后的重复操作。

## 主要改动

- 启动时恢复上次窗口尺寸，并在窗口调整大小后保存逻辑尺寸
- 记住配置页、服务商页、会话记录页上次选择的 CC / Codex / Gemini
- 新增中转直连写入状态记录，服务商列表重启后仍标记上次“已写入”的服务商
- 仪表盘切回中转直连时优先写入上次选择的服务商，而不是默认第一个
- 数据库 schema 升级到 29，补充相关设置字段和写入状态表
