### PR TITLE
feat: 支持动态服务商 Profile

### DIFF
--- a/frontend/src/api/providers.ts
+++ b/frontend/src/api/providers.ts
@@ -1,8 +1,24 @@
 import { invoke } from '@tauri-apps/api/core'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
-import type { Provider, ProviderCreate, ProviderUpdate, TestProviderResult } from '@/types/models'
+import type { Provider, ProviderCreate, ProviderProfileItem, ProviderUpdate, TestProviderResult } from '@/types/models'
 
 export const providersApi = {
+  listProfiles: async (cliType: string): Promise<{ data: ProviderProfileItem[] }> => {
+    const data = await invoke<ProviderProfileItem[]>('get_provider_profiles', { cliType })
+    return { data }
+  },
+  createProfile: async (cliType: string, name: string): Promise<{ data: ProviderProfileItem }> => {
+    const data = await invoke<ProviderProfileItem>('create_provider_profile', { input: { cli_type: cliType, name } })
+    return { data }
+  },
+  renameProfile: async (cliType: string, profile: string, name: string): Promise<{ data: ProviderProfileItem }> => {
+    const data = await invoke<ProviderProfileItem>('rename_provider_profile', { profile, input: { cli_type: cliType, name } })
+    return { data }
+  },
+  deleteProfile: async (cliType: string, profile: string) => {
+    await invoke('delete_provider_profile', { cliType, profile })
+    return { data: null }
+  },
   list: async (cliType?: string, profile?: string): Promise<{ data: Provider[] }> => {
     const args: Record<string, string> = {}
     if (cliType) args.cliType = cliType

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -16,8 +16,16 @@ export const CLI_TABS: { id: CliType; label: string }[] = CLI_TYPES.map((id) => 
   label: CLI_LABELS[id]
 }))
 export const PROFILE_CAPABLE_CLI_TYPES: readonly CliType[] = ['claude_code', 'codex']
-export type ProviderProfile = 'default' | 'profile1' | 'profile2' | 'profile3'
+export type ProviderProfile = string
 export type CliMode = 'proxy_route' | 'provider_direct' | 'official_direct'
+
+export interface ProviderProfileItem {
+  cli_type: CliType
+  name: ProviderProfile
+  label: string
+  is_default: boolean
+  sort_order: number
+}
 
 // Provider types
 export interface ModelMap {

--- a/frontend/src/views/providers/index.vue
+++ b/frontend/src/views/providers/index.vue
@@ -32,15 +32,53 @@
           <button class="v2-seg-btn" :class="{ active: viewMode === 'direct' }" @click="handleSwitchDirect">官方直连</button>
         </div>
 
-        <div v-if="showProfileControls" class="v2-seg">
-          <div class="v2-seg-slider" :style="{ transform: `translateX(${profileTabs.findIndex(p => activeProfile === p.id) * 100}%)`, width: `calc((100% - 8px) / ${profileTabs.length})` }"></div>
+        <div v-if="showProfileControls" class="v2-seg profile-tabs">
+          <div class="v2-seg-slider" :style="{ transform: `translateX(${Math.max(profileTabs.findIndex(p => activeProfile === p.name), 0) * 84}px)`, width: '84px' }"></div>
           <button
             v-for="profile in profileTabs"
-            :key="profile.id"
-            class="v2-seg-btn"
-            :class="{ active: activeProfile === profile.id, disabled: !!profileSwitching }"
-            @click="handleProfileSelect(profile.id)"
-          >{{ profile.label }}</button>
+            :key="profile.name"
+            class="v2-seg-btn profile-tab-btn"
+            :class="{ active: activeProfile === profile.name, disabled: !!profileSwitching }"
+            @click="handleProfileSelect(profile.name)"
+            @dblclick.stop="startProfileRename(profile)"
+          >
+            <input
+              v-if="editingProfileName === profile.name"
+              ref="profileRenameInput"
+              v-model="profileRenameDraft"
+              class="profile-rename-input"
+              :class="{ invalid: profileRenameError }"
+              @click.stop
+              @keydown.enter.prevent="commitProfileRename(profile)"
+              @keydown.esc.prevent="cancelProfileRename"
+              @blur="commitProfileRename(profile)"
+            >
+            <span
+              v-if="editingProfileName === profile.name && profileRenameError"
+              class="profile-rename-error"
+            >
+              {{ profileRenameError }}
+            </span>
+            <span v-if="editingProfileName !== profile.name">{{ profileDisplayLabel(profile) }}</span>
+            <button
+              v-if="!profile.is_default && editingProfileName !== profile.name"
+              class="profile-tab-delete"
+              type="button"
+              title="删除 Profile"
+              @click.stop="handleDeleteProfile(profile)"
+            >
+              ×
+            </button>
+          </button>
+          <button
+            class="v2-seg-btn profile-add"
+            type="button"
+            title="添加 Profile"
+            :disabled="profileLoading"
+            @click="handleAddProfile"
+          >
+            +
+          </button>
         </div>
 
         <el-tooltip
@@ -57,7 +95,7 @@
               <div class="tooltip-item"><span>{{ profileUsageText }}</span></div>
               <div class="profile-cmd">
                 <div class="profile-cmd-head">
-                  <strong>{{ profileLabels[activeProfile] }} 启动命令</strong>
+                  <strong>{{ currentProfileLabel }} 启动命令</strong>
                   <el-tooltip content="复制启动命令" placement="top" effect="light" :show-after="250">
                     <button class="profile-cmd-copy" type="button" :disabled="isCurrentProfileCommandLoading" @click.stop="copyCurrentProfileLaunchCommand">
                       <svg width="14" height="14"><use href="#v2i-copy"/></svg>
@@ -205,6 +243,7 @@
 </template>
 
 <script setup lang="ts">
+import { ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
 import draggable from 'vuedraggable'
 import ProviderRow from './components/ProviderRow.vue'
 import CredentialRow from './components/CredentialRow.vue'
@@ -223,7 +262,7 @@ import { credentialsApi } from '@/api/credentials'
 import { providersApi } from '@/api/providers'
 import { settingsApi } from '@/api/settings'
 import { CLI_TABS, PROFILE_CAPABLE_CLI_TYPES } from '@/types/models'
-import type { Provider, CliType, CliMode, ProviderProfile, CliProfileSettingsStatus, OfficialCredential, OfficialCredentialCreate, TestProviderResult } from '@/types/models'
+import type { Provider, CliType, CliMode, ProviderProfile, ProviderProfileItem, CliProfileSettingsStatus, OfficialCredential, OfficialCredentialCreate, TestProviderResult } from '@/types/models'
 import { getReusableModelName, saveReusableModelName } from '@/utils/modelDefaults'
 
 const providerStore = useProviderStore()
@@ -233,12 +272,14 @@ const settingsStore = useSettingsStore()
 
 const cliTabs = CLI_TABS
 
-const profileTabs: { id: ProviderProfile; label: string }[] = [
-  { id: 'default', label: '默认' },
-  { id: 'profile1', label: 'Profile 1' },
-  { id: 'profile2', label: 'Profile 2' },
-  { id: 'profile3', label: 'Profile 3' }
-]
+const profileTabs = ref<ProviderProfileItem[]>([
+  { cli_type: 'claude_code', name: 'default', label: '默认', is_default: true, sort_order: 0 }
+])
+const profileLoading = ref(false)
+const editingProfileName = ref<ProviderProfile | null>(null)
+const profileRenameDraft = ref('')
+const profileRenameError = ref('')
+const profileRenameInput = ref<HTMLInputElement | null>(null)
 
 const activeCliType = computed({
   get: () => uiStore.providersActiveCliType,
@@ -272,9 +313,9 @@ const currentProviderProfile = computed<ProviderProfile>(() => showProfileContro
 const profileSwitching = ref<ProviderProfile | null>(null)
 let testResultListener: (() => void) | null = null
 
-const profileLabels: Record<ProviderProfile, string> = {
-  default: '默认', profile1: 'Profile 1', profile2: 'Profile 2', profile3: 'Profile 3'
-}
+const currentProfileLabel = computed(() =>
+  profileDisplayLabel(profileTabs.value.find(profile => profile.name === activeProfile.value)) || activeProfile.value
+)
 
 const profileSettingsStatusMap = ref<Partial<Record<string, CliProfileSettingsStatus>>>({})
 const profileCommandLoading = ref<string | null>(null)
@@ -292,6 +333,171 @@ const profileUsageText = computed(() => {
   }
   return '切换到 Profile 时会自动生成对应配置文件，通过对应启动命令启动的 Agent 会路由到对应 Profile 配置的服务商'
 })
+
+function isValidProfileName(name: string) {
+  return /^[A-Za-z0-9_-]{1,64}$/.test(name)
+}
+
+function profileDisplayLabel(profile?: ProviderProfileItem) {
+  if (!profile) return ''
+  if (profile.is_default) return profile.label
+  return profile.label.replace(/_/g, ' ')
+}
+
+function profileNameError(input: string) {
+  const trimmed = input.trim()
+  if (!trimmed) return '不能为空'
+  if (!/^[A-Za-z0-9 _-]+$/.test(trimmed)) return '仅支持英文、数字、空格、下划线和短横线'
+  if (profileNameFromInput(trimmed).length > 64) return '最多 64 个字符'
+  return ''
+}
+
+function profileNameExists(name: string, currentName: string) {
+  return profileTabs.value.some(profile =>
+    profile.name.toLowerCase() === name.toLowerCase() && profile.name !== currentName
+  )
+}
+
+function nextProfileName() {
+  const existing = new Set(profileTabs.value.map(profile => profile.name))
+  let index = profileTabs.value.filter(profile => !profile.is_default).length + 1
+  let name = `profile${index}`
+  while (existing.has(name)) {
+    index += 1
+    name = `profile${index}`
+  }
+  return name
+}
+
+function profileNameFromInput(input: string) {
+  return input.trim().replace(/\s+/g, '_')
+}
+
+async function focusProfileRenameInput() {
+  await nextTick()
+  const input = Array.isArray(profileRenameInput.value)
+    ? profileRenameInput.value[0]
+    : profileRenameInput.value
+  input?.focus()
+  input?.select()
+}
+
+async function loadProfiles() {
+  profileLoading.value = true
+  try {
+    const { data } = await providersApi.listProfiles(activeCliType.value)
+    profileTabs.value = data
+    if (!profileTabs.value.some(profile => profile.name === activeProfile.value)) {
+      activeProfile.value = 'default'
+    }
+  } catch (e: any) {
+    notify(getErrorMessage(e, '加载 Profile 失败'), 'error')
+  } finally {
+    profileLoading.value = false
+  }
+}
+
+async function handleAddProfile() {
+  const internalName = nextProfileName()
+  const displayName = `Profile ${profileTabs.value.filter(profile => !profile.is_default).length + 1}`
+  profileLoading.value = true
+  try {
+    const { data } = await providersApi.createProfile(activeCliType.value, internalName)
+    await loadProfiles()
+    const ok = await ensureProfileReady(data.name)
+    if (ok) activeProfile.value = data.name
+    editingProfileName.value = data.name
+    profileRenameDraft.value = displayName
+    await focusProfileRenameInput()
+  } catch (e: any) {
+    notify(getErrorMessage(e, '创建 Profile 失败'), 'error')
+  } finally {
+    profileLoading.value = false
+  }
+}
+
+async function startProfileRename(profile: ProviderProfileItem) {
+  if (profile.is_default) return
+  editingProfileName.value = profile.name
+  profileRenameDraft.value = profileDisplayLabel(profile)
+  profileRenameError.value = ''
+  await focusProfileRenameInput()
+}
+
+function cancelProfileRename() {
+  editingProfileName.value = null
+  profileRenameDraft.value = ''
+  profileRenameError.value = ''
+}
+
+async function commitProfileRename(profile: ProviderProfileItem) {
+  if (editingProfileName.value !== profile.name) return
+  const error = profileNameError(profileRenameDraft.value)
+  if (error) {
+    profileRenameError.value = error
+    await focusProfileRenameInput()
+    return
+  }
+
+  const name = profileNameFromInput(profileRenameDraft.value)
+  if (name === profile.name) {
+    cancelProfileRename()
+    return
+  }
+  if (profileNameExists(name, profile.name)) {
+    profileRenameError.value = '名称已存在'
+    await focusProfileRenameInput()
+    return
+  }
+  if (!isValidProfileName(name)) {
+    profileRenameError.value = '仅支持英文、数字、空格、下划线和短横线'
+    await focusProfileRenameInput()
+    return
+  }
+
+  profileLoading.value = true
+  try {
+    const oldProfile = profile.name
+    const { data } = await providersApi.renameProfile(activeCliType.value, oldProfile, name)
+    const oldPrefix = `${activeCliType.value}_${oldProfile}`
+    const newPrefix = `${activeCliType.value}_${data.name}`
+    if (providerStore.providersMap[oldPrefix]) {
+      providerStore.providersMap[newPrefix] = providerStore.providersMap[oldPrefix]
+      delete providerStore.providersMap[oldPrefix]
+    }
+    profileSettingsStatusMap.value = {}
+    if (activeProfile.value === oldProfile) activeProfile.value = data.name
+    await loadProfiles()
+    await ensureProfileReady(data.name)
+    await providerStore.fetchProviders(activeCliType.value as CliType, data.name)
+    cancelProfileRename()
+  } catch (e: any) {
+    notify(getErrorMessage(e, '重命名 Profile 失败'), 'error')
+    await focusProfileRenameInput()
+  } finally {
+    profileLoading.value = false
+  }
+}
+
+async function handleDeleteProfile(profile: ProviderProfileItem) {
+  if (profile.is_default) return
+  try {
+    await confirm(`确定删除 Profile「${profileDisplayLabel(profile)}」？该 Profile 下的服务商和定时任务会一并删除。`, '确认')
+    profileLoading.value = true
+    const deletedIndex = profileTabs.value.findIndex(item => item.name === profile.name)
+    const previousProfile = profileTabs.value[deletedIndex - 1].name
+    await providersApi.deleteProfile(activeCliType.value, profile.name)
+    delete providerStore.providersMap[`${activeCliType.value}_${profile.name}`]
+    profileSettingsStatusMap.value = {}
+    if (activeProfile.value === profile.name) activeProfile.value = previousProfile
+    await loadProfiles()
+    await providerStore.fetchProviders(activeCliType.value as CliType, currentProviderProfile.value)
+  } catch (e: any) {
+    if (e !== 'cancel') notify(getErrorMessage(e, '删除 Profile 失败'), 'error')
+  } finally {
+    profileLoading.value = false
+  }
+}
 
 function handleSwitchProxy() {
   if (viewMode.value === 'proxy') return
@@ -506,7 +712,8 @@ async function copyCurrentProfileLaunchCommand() {
   if (!command) return
   try {
     await navigator.clipboard.writeText(command)
-    notify(`已复制 ${profileLabels[profile]} 启动命令`)
+    const label = profileDisplayLabel(profileTabs.value.find(item => item.name === profile)) || profile
+    notify(`已复制 ${label} 启动命令`)
   } catch {
     notify('复制失败', 'error')
   }
@@ -541,7 +748,7 @@ async function ensureProfileReady(profile: ProviderProfile): Promise<boolean> {
       notify(`写入后仍未检测到有效配置：${ensured.path}`, 'error')
       return false
     }
-    notify(`已写入 ${ensured.path}`)
+
     return true
   } catch (e: any) {
     notify(getErrorMessage(e, '写入 Profile 配置失败'), 'error')
@@ -565,6 +772,7 @@ async function ensureCurrentProfileOrFallback(): Promise<ProviderProfile> {
 }
 
 watch(() => activeCliType.value, async (cliType) => {
+  await loadProfiles()
   const profile = await ensureCurrentProfileOrFallback()
   const key = providerStore.getCacheKey(cliType as CliType, profile)
   if (!providerStore.providersMap[key] || providerStore.providersMap[key].length === 0) {
@@ -579,6 +787,11 @@ watch(() => activeProfile.value, (profile) => {
     providerStore.fetchProviders(activeCliType.value as CliType, profile)
   }
 })
+watch(profileRenameDraft, (value) => {
+  if (!editingProfileName.value) return
+  profileRenameError.value = profileNameError(value)
+})
+
 watch(() => viewMode.value, async (mode) => {
   if (mode !== 'proxy') return
   const profile = await ensureCurrentProfileOrFallback()
@@ -836,6 +1049,7 @@ function getUnblacklistTime(provider: Provider): string {
 
 onMounted(async () => {
   await settingsStore.fetchSettings()
+  await loadProfiles()
   const profile = await ensureCurrentProfileOrFallback()
   providerStore.fetchProviders(activeCliType.value as CliType, profile)
   credentialStore.fetchCredentials(activeCliType.value as CliType)
@@ -870,6 +1084,17 @@ onUnmounted(() => {
 .prov-page { flex: 1; min-height: 0; display: flex; flex-direction: column; margin-top: -16px; }
 
 .prov-clitabs { flex-shrink: 0; margin-bottom: 16px; }
+.profile-tabs .v2-seg-btn.active { pointer-events: auto; }
+.profile-tabs .v2-seg-btn { position: relative; }
+.profile-tabs:has(.v2-seg-slider) { grid-auto-columns: auto; }
+.profile-tabs:has(.v2-seg-slider) .v2-seg-btn { min-width: 0; }
+.profile-tab-btn { width: 84px; min-width: 84px; padding-left: 8px; padding-right: 8px; }
+.profile-tab-delete { margin-left: 8px; border: 0; background: transparent; color: var(--v2-text-3); cursor: pointer; font-size: 14px; line-height: 1; padding: 0 2px; pointer-events: auto; }
+.profile-tab-delete:hover { color: var(--v2-danger); }
+.profile-rename-input { width: 72px; max-width: 72px; min-width: 72px; height: 18px; border: 0; outline: 0; background: transparent; color: inherit; font: inherit; line-height: 18px; text-align: center; padding: 0; }
+.profile-rename-input.invalid { border: 1px solid var(--v2-danger); border-radius: 4px; color: var(--v2-danger); }
+.profile-rename-error { position: absolute; top: calc(100% + 4px); left: 50%; z-index: 10; box-sizing: border-box; min-width: max-content; transform: translateX(-50%); border: 1px solid var(--v2-danger); border-radius: 4px; background: var(--v2-surface); color: var(--v2-danger); font-size: 12px; line-height: 18px; padding: 2px 6px; white-space: nowrap; box-shadow: 0 4px 12px var(--v2-shadow); }
+.profile-add { width: 30px; min-width: 30px; height: 30px; padding: 0; display: inline-flex; align-items: center; justify-content: center; }
 
 .prov-shell { flex: 1; min-height: 0; display: flex; flex-direction: column; padding: 0; overflow: hidden; }
 

--- a/frontend/src/views/scheduled-tasks/index.vue
+++ b/frontend/src/views/scheduled-tasks/index.vue
@@ -177,6 +177,7 @@ import {
   type Provider,
   type ProviderKeepalivePayload,
   type ProviderProfile,
+  type ProviderProfileItem,
   type ScheduledTask,
   type ScheduledTaskRun,
   type ScheduledTaskRunItem,
@@ -185,16 +186,26 @@ import {
   type ScheduledTaskType
 } from '@/types/models'
 
-const profileTabs: { id: ProviderProfile; label: string }[] = [
-  { id: 'default', label: '默认' },
-  { id: 'profile1', label: 'Profile 1' },
-  { id: 'profile2', label: 'Profile 2' },
-  { id: 'profile3', label: 'Profile 3' }
+const profileTabs = ref<ProviderProfileItem[]>([
+  { cli_type: 'claude_code', name: 'default', label: '默认', is_default: true, sort_order: 0 }
+])
+
+const hourOptions: AppSelectOption[] = Array.from({ length: 24 }, (_, hour) => {
+  const value = String(hour).padStart(2, '0')
+  return { label: value, value }
+})
+const minuteOptions: AppSelectOption[] = Array.from({ length: 60 }, (_, minute) => {
+  const value = String(minute).padStart(2, '0')
+  return { label: value, value }
+})
+const targetModeOptions: AppSelectOption[] = [
+  { label: '全部服务商', value: 'all' },
+  { label: '指定服务商', value: 'selected' }
 ]
-const hourOptions: AppSelectOption[] = Array.from({ length: 24 }, (_, h) => ({ label: String(h).padStart(2, '0'), value: String(h).padStart(2, '0') }))
-const minuteOptions: AppSelectOption[] = Array.from({ length: 60 }, (_, m) => ({ label: String(m).padStart(2, '0'), value: String(m).padStart(2, '0') }))
-const targetModeOptions: AppSelectOption[] = [{ label: '全部服务商', value: 'all' }, { label: '指定服务商', value: 'selected' }]
-const scheduleTypeOptions: AppSelectOption[] = [{ label: '执行间隔', value: 'interval' }, { label: '定期执行', value: 'daily' }]
+const scheduleTypeOptions: AppSelectOption[] = [
+  { label: '执行间隔', value: 'interval' },
+  { label: '定期执行', value: 'daily' }
+]
 
 interface FormState {
   name: string
@@ -213,7 +224,14 @@ interface FormState {
 }
 
 const cliSelectOptions: AppSelectOption[] = CLI_TABS.map(cli => ({ label: cli.label, value: cli.id }))
-const profileSelectOptions: AppSelectOption[] = profileTabs.map(p => ({ label: p.label, value: p.id }))
+function profileDisplayLabel(profile: ProviderProfileItem) {
+  if (profile.is_default) return profile.label
+  return profile.label.replace(/_/g, ' ')
+}
+
+const profileSelectOptions = computed<AppSelectOption[]>(() =>
+  profileTabs.value.map(profile => ({ label: profileDisplayLabel(profile), value: profile.name }))
+)
 const tasks = ref<ScheduledTask[]>([])
 const loading = ref(false)
 const showDialog = ref(false)
@@ -271,6 +289,15 @@ async function fetchProviders() {
     providersLoading.value = false
   }
 }
+
+async function fetchProfiles() {
+  const { data } = await providersApi.listProfiles(form.value.cli_type)
+  profileTabs.value = data
+  if (!profileTabs.value.some(profile => profile.name === form.value.profile)) {
+    form.value.profile = 'default'
+  }
+}
+
 function toggleProvider(id: number) {
   const i = form.value.provider_ids.indexOf(id)
   if (i >= 0) form.value.provider_ids.splice(i, 1)
@@ -284,6 +311,7 @@ function handleAdd() {
   form.value = defaultForm()
   providerOptions.value = []
   showDialog.value = true
+  void fetchProfiles()
   void fetchProviders()
 }
 function handleEdit(task: ScheduledTask) {
@@ -306,6 +334,7 @@ function handleEdit(task: ScheduledTask) {
     retry_interval_minutes: task.retry_interval_minutes
   }
   showDialog.value = true
+  void fetchProfiles()
   void fetchProviders()
 }
 async function handleSave() {
@@ -504,6 +533,7 @@ function handleScheduledTaskChange() {
 
 onMounted(async () => {
   try {
+    await fetchProfiles()
     await fetchTasks()
     hasLoadedTasks = true
   } catch (e: any) {
@@ -521,10 +551,18 @@ onUnmounted(() => {
     scheduledTaskListener = null
   }
 })
-watch(() => form.value.cli_type, (cliType, oldCliType) => {
-  if (!PROFILE_CAPABLE_CLI_TYPES.includes(cliType)) form.value.profile = 'default'
-  if (!oldCliType || form.value.model_name === getReusableModelName(oldCliType)) form.value.model_name = getReusableModelName(cliType)
-  if (showDialog.value) void fetchProviders()
+
+watch(() => form.value.cli_type, async (cliType, oldCliType) => {
+  if (!PROFILE_CAPABLE_CLI_TYPES.includes(cliType)) {
+    form.value.profile = 'default'
+  }
+  if (!oldCliType || form.value.model_name === getReusableModelName(oldCliType)) {
+    form.value.model_name = getReusableModelName(cliType)
+  }
+  if (showDialog.value) {
+    await fetchProfiles()
+    void fetchProviders()
+  }
 })
 watch(() => form.value.profile, () => {
   if (showDialog.value) void fetchProviders()

--- a/src-tauri/src/api/handlers.rs
+++ b/src-tauri/src/api/handlers.rs
@@ -88,7 +88,7 @@ pub async fn proxy_handler_catchall(
     let provider_with_maps = match select_provider(
         &state.db,
         cli_type.as_str(),
-        provider_profile,
+        &provider_profile,
         extracted_model.as_deref(),
     )
     .await

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -16,8 +16,8 @@ use crate::db::models::{
 };
 use crate::services::proxy::CliType;
 use crate::services::routing::{
-    gateway_token_for_profile, normalize_profile, DEFAULT_PROFILE, PROFILE1, PROFILE2, PROFILE3,
-    PROVIDER_PROFILES,
+    gateway_token_for_profile, is_valid_profile_name, normalize_profile, normalize_profile_name,
+    DEFAULT_PROFILE,
 };
 use crate::services::skill::{self, is_local_repo_source, InstalledSkillManifestEntry};
 use crate::time::{local_compact_datetime, now_timestamp};
@@ -132,13 +132,12 @@ fn serialize_toml_table<T: Serialize>(value: &T, context: &str) -> Result<toml_e
     Ok(serialize_toml_document(value, context)?.as_table().clone())
 }
 
-fn codex_gateway_provider_name(profile: &str) -> Option<&'static str> {
-    match normalize_profile(Some(profile))? {
-        DEFAULT_PROFILE => Some("ccg-gateway"),
-        PROFILE1 => Some("ccg-gateway-profile1"),
-        PROFILE2 => Some("ccg-gateway-profile2"),
-        PROFILE3 => Some("ccg-gateway-profile3"),
-        _ => None,
+fn codex_gateway_provider_name(profile: &str) -> Option<String> {
+    let profile = normalize_profile(Some(profile))?;
+    if profile == DEFAULT_PROFILE {
+        Some("ccg-gateway".to_string())
+    } else {
+        Some(format!("ccg-gateway-{}", profile))
     }
 }
 
@@ -175,23 +174,23 @@ fn apply_codex_gateway_provider_config(
     doc: &mut toml_edit::DocumentMut,
     gateway_url: &str,
     profile: &str,
-) -> Result<&'static str> {
+) -> Result<String> {
     let profile = normalize_profile(Some(profile))
-        .ok_or_else(|| format!("profile 只能是 {}", PROVIDER_PROFILES.join(" / ")))?;
-    let provider_name = codex_gateway_provider_name(profile)
-        .ok_or_else(|| format!("profile 只能是 {}", PROVIDER_PROFILES.join(" / ")))?;
-    let gateway_token = gateway_token_for_profile(profile)
-        .ok_or_else(|| format!("profile 只能是 {}", PROVIDER_PROFILES.join(" / ")))?;
+        .ok_or_else(|| invalid_profile_message())?;
+    let provider_name = codex_gateway_provider_name(&profile)
+        .ok_or_else(|| invalid_profile_message())?;
+    let gateway_token = gateway_token_for_profile(&profile)
+        .ok_or_else(|| invalid_profile_message())?;
 
     let mut provider_table = toml_edit::Table::new();
-    provider_table["name"] = toml_edit::value(provider_name);
+    provider_table["name"] = toml_edit::value(provider_name.as_str());
     provider_table["base_url"] = toml_edit::value(gateway_url.trim_end_matches('/'));
     provider_table["wire_api"] = toml_edit::value("responses");
     provider_table["requires_openai_auth"] = toml_edit::value(false);
     provider_table["experimental_bearer_token"] = toml_edit::value(gateway_token);
 
     let model_providers = ensure_toml_table(doc, "model_providers");
-    model_providers[provider_name] = toml_edit::Item::Table(provider_table);
+    model_providers[provider_name.as_str()] = toml_edit::Item::Table(provider_table);
 
     Ok(provider_name)
 }
@@ -212,27 +211,26 @@ fn apply_codex_gateway_named_profile_config(
     profile: &str,
 ) -> Result<()> {
     let profile = normalize_profile(Some(profile))
-        .ok_or_else(|| format!("profile 只能是 {}", PROVIDER_PROFILES.join(" / ")))?;
+        .ok_or_else(|| invalid_profile_message())?;
     if profile == DEFAULT_PROFILE {
         return Ok(());
     }
 
-    let provider_name = apply_codex_gateway_provider_config(doc, gateway_url, profile)?;
+    let provider_name = apply_codex_gateway_provider_config(doc, gateway_url, &profile)?;
     doc["model_provider"] = toml_edit::value(provider_name);
 
     Ok(())
 }
 
-fn codex_provider_direct_provider_name(profile: &str) -> Result<&'static str> {
+fn codex_provider_direct_provider_name(profile: &str) -> Result<String> {
     let profile = normalize_profile(Some(profile))
-        .ok_or_else(|| format!("profile 只能是 {}", PROVIDER_PROFILES.join(" / ")))?;
-    codex_gateway_provider_name(profile)
-        .ok_or_else(|| format!("profile 只能是 {}", PROVIDER_PROFILES.join(" / ")))
+        .ok_or_else(|| invalid_profile_message())?;
+    codex_gateway_provider_name(&profile).ok_or_else(|| invalid_profile_message())
 }
 
 fn codex_legacy_provider_direct_provider_name(profile: &str) -> Result<Option<String>> {
     let profile = normalize_profile(Some(profile))
-        .ok_or_else(|| format!("profile 只能是 {}", PROVIDER_PROFILES.join(" / ")))?;
+        .ok_or_else(|| invalid_profile_message())?;
     Ok((profile != DEFAULT_PROFILE).then(|| format!("ccg-provider-direct-{}", profile)))
 }
 
@@ -251,7 +249,7 @@ fn codex_provider_entry_uses_gateway_token(
         .and_then(|provider| provider.get("experimental_bearer_token"))
         .and_then(|item| item.as_str())
         .map(str::trim)
-        .map(|token| token == expected_token)
+        .map(|token| token == expected_token.as_str())
         .unwrap_or(false)
 }
 
@@ -288,8 +286,8 @@ fn remove_codex_provider_direct_entry(
     if let Some(legacy_provider_name) = codex_legacy_provider_direct_provider_name(profile)? {
         remove_codex_provider_entry(doc, &legacy_provider_name);
     }
-    if !codex_provider_entry_uses_gateway_token(doc, provider_name, profile) {
-        remove_codex_provider_entry(doc, provider_name);
+    if !codex_provider_entry_uses_gateway_token(doc, &provider_name, profile) {
+        remove_codex_provider_entry(doc, &provider_name);
     }
     Ok(())
 }
@@ -301,15 +299,15 @@ fn apply_codex_provider_direct_config(
     let provider_name = codex_provider_direct_provider_name(&provider.profile)?;
 
     let mut provider_table = toml_edit::Table::new();
-    provider_table["name"] = toml_edit::value(provider_name);
+    provider_table["name"] = toml_edit::value(provider_name.as_str());
     provider_table["base_url"] = toml_edit::value(provider.base_url.trim_end_matches('/'));
     provider_table["wire_api"] = toml_edit::value("responses");
     provider_table["requires_openai_auth"] = toml_edit::value(false);
     provider_table["experimental_bearer_token"] = toml_edit::value(provider.api_key.as_str());
 
     let model_providers = ensure_toml_table(doc, "model_providers");
-    model_providers[provider_name] = toml_edit::Item::Table(provider_table);
-    doc["model_provider"] = toml_edit::value(provider_name);
+    model_providers[provider_name.as_str()] = toml_edit::Item::Table(provider_table);
+    doc["model_provider"] = toml_edit::value(provider_name.as_str());
 
     Ok(provider_name.to_string())
 }
@@ -346,7 +344,7 @@ mod tests {
     fn codex_provider_direct_profile_uses_gateway_profile_name() {
         let mut doc = toml_edit::DocumentMut::new();
 
-        apply_codex_provider_direct_config(&mut doc, &codex_provider(PROFILE1)).unwrap();
+        apply_codex_provider_direct_config(&mut doc, &codex_provider("profile1")).unwrap();
 
         assert_eq!(
             doc.get("model_provider").and_then(|item| item.as_str()),
@@ -370,13 +368,13 @@ mod tests {
     #[test]
     fn remove_codex_provider_direct_profile_removes_direct_and_legacy_names() {
         let mut doc = toml_edit::DocumentMut::new();
-        apply_codex_provider_direct_config(&mut doc, &codex_provider(PROFILE1)).unwrap();
+        apply_codex_provider_direct_config(&mut doc, &codex_provider("profile1")).unwrap();
         let mut legacy_provider = toml_edit::Table::new();
         legacy_provider["name"] = toml_edit::value("Upstream Provider");
         ensure_toml_table(&mut doc, "model_providers")["ccg-provider-direct-profile1"] =
             toml_edit::Item::Table(legacy_provider);
 
-        remove_codex_provider_direct_entry(&mut doc, PROFILE1).unwrap();
+        remove_codex_provider_direct_entry(&mut doc, "profile1").unwrap();
 
         assert!(doc.get("model_provider").is_none());
         assert!(doc.get("model_providers").is_none());
@@ -385,10 +383,10 @@ mod tests {
     #[test]
     fn remove_codex_provider_direct_profile_preserves_gateway_profile() {
         let mut doc = toml_edit::DocumentMut::new();
-        apply_codex_gateway_named_profile_config(&mut doc, "http://127.0.0.1:3456/v1", PROFILE1)
+        apply_codex_gateway_named_profile_config(&mut doc, "http://127.0.0.1:3456/v1", "profile1")
             .unwrap();
 
-        remove_codex_provider_direct_entry(&mut doc, PROFILE1).unwrap();
+        remove_codex_provider_direct_entry(&mut doc, "profile1").unwrap();
 
         assert_eq!(
             doc.get("model_provider").and_then(|item| item.as_str()),
@@ -447,7 +445,7 @@ fn migrate_codex_legacy_profile_config(
             .get_mut("model_providers")
             .and_then(|item| item.as_table_mut())
         {
-            if model_providers.remove(provider_name).is_some() {
+            if model_providers.remove(provider_name.as_str()).is_some() {
                 changed = true;
             }
             model_providers.is_empty()
@@ -470,7 +468,7 @@ fn remove_codex_default_gateway_entry(doc: &mut toml_edit::DocumentMut) {
     if doc
         .get("model_provider")
         .and_then(|item| item.as_str())
-        .map(|provider| provider == default_provider_name)
+        .map(|provider| provider == default_provider_name.as_str())
         .unwrap_or(false)
     {
         doc.remove("model_provider");
@@ -478,7 +476,7 @@ fn remove_codex_default_gateway_entry(doc: &mut toml_edit::DocumentMut) {
 
     if doc.get("model_providers").is_some() {
         let model_providers = ensure_toml_table(doc, "model_providers");
-        model_providers.remove(default_provider_name);
+        model_providers.remove(&default_provider_name);
         if model_providers.is_empty() {
             doc.remove("model_providers");
         }
@@ -603,9 +601,68 @@ fn map_db_error(e: sqlx::Error) -> String {
     err_str
 }
 
-fn validate_provider_profile(profile: Option<&str>) -> Result<&'static str> {
-    normalize_profile(profile)
-        .ok_or_else(|| format!("profile 只能是 {}", PROVIDER_PROFILES.join(" / ")))
+fn invalid_profile_message() -> String {
+    "Profile 名称仅支持英文、数字、空格、下划线和短横线".to_string()
+}
+
+fn validate_provider_profile(profile: Option<&str>) -> Result<String> {
+    normalize_profile(profile).ok_or_else(invalid_profile_message)
+}
+
+async fn list_provider_profile_names(db: &SqlitePool) -> Result<Vec<String>> {
+    ensure_legacy_provider_profiles(db).await?;
+    let rows: Vec<(String,)> =
+        sqlx::query_as("SELECT DISTINCT name FROM provider_profiles ORDER BY name")
+            .fetch_all(db)
+            .await
+            .map_err(|e| e.to_string())?;
+
+    let mut profiles = Vec::with_capacity(rows.len() + 1);
+    profiles.push(DEFAULT_PROFILE.to_string());
+    profiles.extend(rows.into_iter().map(|(name,)| name));
+    Ok(profiles)
+}
+
+async fn ensure_legacy_provider_profiles(db: &SqlitePool) -> Result<()> {
+    let now = now_timestamp();
+    let legacy_profiles: Vec<(String, String)> = sqlx::query_as(
+        r#"
+        SELECT DISTINCT cli_type, profile FROM providers
+        WHERE profile <> ?
+          AND NOT EXISTS (
+              SELECT 1 FROM provider_profiles
+              WHERE provider_profiles.cli_type = providers.cli_type
+                AND provider_profiles.name = providers.profile
+          )
+        ORDER BY cli_type, profile
+        "#,
+    )
+    .bind(DEFAULT_PROFILE)
+    .fetch_all(db)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    for (index, (cli_type, profile)) in legacy_profiles.into_iter().enumerate() {
+        if !is_valid_profile_name(&profile) {
+            continue;
+        }
+        sqlx::query(
+            r#"
+            INSERT OR IGNORE INTO provider_profiles (cli_type, name, sort_order, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(&cli_type)
+        .bind(&profile)
+        .bind((index as i64 + 1) * 10)
+        .bind(now)
+        .bind(now)
+        .execute(db)
+        .await
+        .map_err(map_db_error)?;
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Serialize)]
@@ -1198,7 +1255,7 @@ fn codex_profile_launch_command(profile: &str) -> String {
     if profile == DEFAULT_PROFILE {
         "codex".to_string()
     } else {
-        format!("codex --profile {}", profile)
+        format!("codex --profile {}", shell_quote_path(profile))
     }
 }
 
@@ -1250,24 +1307,24 @@ async fn claude_profile_settings_status(
     profile: &str,
     gateway_url: &str,
 ) -> Result<ClaudeProfileSettingsStatus> {
-    let profile = normalize_profile(Some(profile))
-        .ok_or_else(|| format!("profile 只能是 {}", PROVIDER_PROFILES.join(" / ")))?;
-    let filename = cli_helpers::claude_settings_filename(profile);
+    let profile = normalize_profile(Some(profile)).ok_or_else(invalid_profile_message)?;
+    let filename = cli_helpers::claude_settings_filename(&profile);
     let config_dir = get_cli_config_dir_path(db, "claude_code").await;
-    let config_path = config_dir.join(filename);
-    let gateway_token = gateway_token_for_profile(profile).unwrap_or("ccg-gateway");
+    let config_path = config_dir.join(&filename);
+    let gateway_token =
+        gateway_token_for_profile(&profile).unwrap_or_else(|| "ccg-gateway".to_string());
     let path = shrink_home_path(&config_path.to_string_lossy());
-    let launch_command = claude_profile_launch_command(profile, &config_path);
+    let launch_command = claude_profile_launch_command(&profile, &config_path);
     let exists = tokio::fs::try_exists(&config_path).await.unwrap_or(false);
     let uses_gateway = if profile == DEFAULT_PROFILE {
         true
     } else {
-        claude_settings_uses_gateway(&config_path, gateway_url, gateway_token).await
+        claude_settings_uses_gateway(&config_path, gateway_url, &gateway_token).await
     };
 
     Ok(ClaudeProfileSettingsStatus {
         profile: profile.to_string(),
-        filename: filename.to_string(),
+        filename,
         path,
         launch_command,
         exists,
@@ -1349,7 +1406,7 @@ async fn codex_profile_uses_gateway(
         &profile_doc,
         &provider_name,
         expected_url,
-        Some(expected_token),
+        Some(expected_token.as_str()),
     ) {
         return true;
     }
@@ -1368,7 +1425,7 @@ async fn codex_profile_uses_gateway(
         &base_doc,
         &provider_name,
         expected_url,
-        Some(expected_token),
+        Some(expected_token.as_str()),
     )
 }
 
@@ -1386,7 +1443,7 @@ fn codex_default_provider_uses_gateway(doc: &toml_edit::DocumentMut, gateway_url
         return false;
     }
 
-    codex_provider_uses_gateway(doc, "ccg-gateway", gateway_url, Some(expected_token))
+    codex_provider_uses_gateway(doc, "ccg-gateway", gateway_url, Some(expected_token.as_str()))
 }
 
 async fn codex_profile_settings_status(
@@ -1394,21 +1451,20 @@ async fn codex_profile_settings_status(
     profile: &str,
     gateway_url: &str,
 ) -> Result<CodexProfileSettingsStatus> {
-    let profile = normalize_profile(Some(profile))
-        .ok_or_else(|| format!("profile 只能是 {}", PROVIDER_PROFILES.join(" / ")))?;
+    let profile = normalize_profile(Some(profile)).ok_or_else(invalid_profile_message)?;
     let config_dir = get_cli_config_dir_path(db, "codex").await;
-    let config_path = codex_profile_config_path(&config_dir, profile);
+    let config_path = codex_profile_config_path(&config_dir, &profile);
     let path = shrink_home_path(&config_path.to_string_lossy());
     let exists = tokio::fs::try_exists(&config_path).await.unwrap_or(false);
-    let filename = codex_profile_config_filename(profile);
+    let filename = codex_profile_config_filename(&profile);
 
     Ok(CodexProfileSettingsStatus {
         profile: profile.to_string(),
         filename,
         path,
-        launch_command: codex_profile_launch_command(profile),
+        launch_command: codex_profile_launch_command(&profile),
         exists,
-        uses_gateway: codex_profile_uses_gateway(&config_dir, profile, gateway_url).await,
+        uses_gateway: codex_profile_uses_gateway(&config_dir, &profile, gateway_url).await,
     })
 }
 
@@ -1511,7 +1567,7 @@ async fn write_claude_provider_direct_config(
 ) -> Result<()> {
     let profile = validate_provider_profile(Some(&provider.profile))?;
     let config_dir = get_cli_config_dir_path(db, "claude_code").await;
-    let config_path = config_dir.join(cli_helpers::claude_settings_filename(profile));
+    let config_path = config_dir.join(cli_helpers::claude_settings_filename(&profile));
     let use_merge = get_config_write_mode(db, "claude_code").await == "merge";
     let default_config = if profile == DEFAULT_PROFILE {
         get_cli_default_config(db, "claude_code").await?
@@ -1537,7 +1593,7 @@ async fn write_codex_provider_direct_config(
 ) -> Result<()> {
     let profile = validate_provider_profile(Some(&provider.profile))?;
     let codex_dir = get_cli_config_dir_path(db, "codex").await;
-    let config_path = codex_profile_config_path(&codex_dir, profile);
+    let config_path = codex_profile_config_path(&codex_dir, &profile);
     let use_merge = get_config_write_mode(db, "codex").await == "merge";
 
     tokio::fs::create_dir_all(&codex_dir).await.map_err(|e| {
@@ -1589,10 +1645,10 @@ async fn write_codex_provider_direct_config(
         }
     }
 
-    if let Some(gateway_name) = codex_gateway_provider_name(profile) {
-        remove_codex_provider_entry(&mut final_doc, gateway_name);
+    if let Some(gateway_name) = codex_gateway_provider_name(&profile) {
+        remove_codex_provider_entry(&mut final_doc, &gateway_name);
     }
-    remove_codex_provider_direct_entry(&mut final_doc, profile)?;
+    remove_codex_provider_direct_entry(&mut final_doc, &profile)?;
     apply_codex_provider_direct_config(&mut final_doc, provider)?;
 
     tokio::fs::write(&config_path, final_doc.to_string())
@@ -1747,7 +1803,7 @@ async fn claude_provider_direct_active_provider_id(
 ) -> Result<Option<i64>> {
     let profile = validate_provider_profile(Some(profile))?;
     let config_dir = get_cli_config_dir_path(db, "claude_code").await;
-    let config_path = config_dir.join(cli_helpers::claude_settings_filename(profile));
+    let config_path = config_dir.join(cli_helpers::claude_settings_filename(&profile));
     if !tokio::fs::try_exists(&config_path).await.unwrap_or(false) {
         return Ok(None);
     }
@@ -1772,7 +1828,7 @@ async fn claude_provider_direct_active_provider_id(
         return Ok(None);
     };
 
-    provider_match_id(db, "claude_code", profile, base_url, api_key).await
+    provider_match_id(db, "claude_code", &profile, base_url, api_key).await
 }
 
 async fn codex_provider_direct_active_provider_id(
@@ -1781,7 +1837,7 @@ async fn codex_provider_direct_active_provider_id(
 ) -> Result<Option<i64>> {
     let profile = validate_provider_profile(Some(profile))?;
     let codex_dir = get_cli_config_dir_path(db, "codex").await;
-    let config_path = codex_profile_config_path(&codex_dir, profile);
+    let config_path = codex_profile_config_path(&codex_dir, &profile);
     if !tokio::fs::try_exists(&config_path).await.unwrap_or(false) {
         return Ok(None);
     }
@@ -1815,7 +1871,7 @@ async fn codex_provider_direct_active_provider_id(
         return Ok(None);
     };
 
-    provider_match_id(db, "codex", profile, base_url, api_key).await
+    provider_match_id(db, "codex", &profile, base_url, api_key).await
 }
 
 async fn gemini_provider_direct_active_provider_id(db: &SqlitePool) -> Result<Option<i64>> {
@@ -1858,7 +1914,10 @@ async fn provider_direct_active_provider_id(
     }
 }
 
-async fn remove_codex_provider_direct_config_content(config_path: &std::path::Path) -> Result<()> {
+async fn remove_codex_provider_direct_config_content(
+    config_path: &std::path::Path,
+    profiles: &[String],
+) -> Result<()> {
     if !tokio::fs::try_exists(config_path).await.unwrap_or(false) {
         return Ok(());
     }
@@ -1878,7 +1937,7 @@ async fn remove_codex_provider_direct_config_content(config_path: &std::path::Pa
         }
     };
 
-    for profile in PROVIDER_PROFILES {
+    for profile in profiles {
         remove_codex_provider_direct_entry(&mut doc, profile)?;
     }
 
@@ -1888,11 +1947,12 @@ async fn remove_codex_provider_direct_config_content(config_path: &std::path::Pa
 }
 
 async fn remove_provider_direct_config_async(db: &SqlitePool, cli_type: &str) -> Result<()> {
+    let profiles = list_provider_profile_names(db).await?;
     match cli_type {
         "claude_code" => {
             let config_dir = get_cli_config_dir_path(db, "claude_code").await;
             let gateway_config = claude_gateway_json_template();
-            for profile in PROVIDER_PROFILES {
+            for profile in &profiles {
                 let config_path = config_dir.join(cli_helpers::claude_settings_filename(profile));
                 remove_json_config_content(&config_path, &gateway_config, "", &gateway_config)
                     .await?;
@@ -1901,9 +1961,9 @@ async fn remove_provider_direct_config_async(db: &SqlitePool, cli_type: &str) ->
         }
         "codex" => {
             let config_dir = get_cli_config_dir_path(db, "codex").await;
-            for profile in PROVIDER_PROFILES {
+            for profile in &profiles {
                 let config_path = codex_profile_config_path(&config_dir, profile);
-                remove_codex_provider_direct_config_content(&config_path).await?;
+                remove_codex_provider_direct_config_content(&config_path, &profiles).await?;
             }
             Ok(())
         }
@@ -1933,13 +1993,13 @@ async fn sync_claude_code_config(
     let use_merge = write_mode == "merge";
 
     if enabled {
-        for profile in PROVIDER_PROFILES {
-            if !claude_profile_in_scope(scope, profile) {
+        for profile in list_provider_profile_names(db).await? {
+            if !claude_profile_in_scope(scope, &profile) {
                 continue;
             }
 
-            let gateway_token = gateway_token_for_profile(profile).unwrap_or("ccg-gateway");
-            let config_path = config_dir.join(cli_helpers::claude_settings_filename(profile));
+            let gateway_token = gateway_token_for_profile(&profile).unwrap_or_else(|| "ccg-gateway".to_string());
+            let config_path = config_dir.join(cli_helpers::claude_settings_filename(&profile));
             // 非 default profile 只写网关必要字段，不合并用户预设配置
             let profile_default_config = if profile == DEFAULT_PROFILE {
                 default_config
@@ -1957,18 +2017,18 @@ async fn sync_claude_code_config(
                 profile_previous_config,
                 use_merge,
                 gateway_url,
-                gateway_token,
+                &gateway_token,
             )
             .await?;
         }
     } else {
         let gateway_config = claude_gateway_json_template();
-        for profile in PROVIDER_PROFILES {
-            if !claude_profile_in_scope(scope, profile) {
+        for profile in list_provider_profile_names(db).await? {
+            if !claude_profile_in_scope(scope, &profile) {
                 continue;
             }
 
-            let config_path = config_dir.join(cli_helpers::claude_settings_filename(profile));
+            let config_path = config_dir.join(cli_helpers::claude_settings_filename(&profile));
             remove_json_config_content(
                 &config_path,
                 &gateway_config,

--- a/src-tauri/src/commands/cli_helpers.rs
+++ b/src-tauri/src/commands/cli_helpers.rs
@@ -1,14 +1,13 @@
 use std::path::{Path, PathBuf};
 
-use crate::services::routing::{DEFAULT_PROFILE, PROFILE1, PROFILE2, PROFILE3};
+use crate::services::routing::{normalize_profile, DEFAULT_PROFILE};
 
-pub fn claude_settings_filename(profile: &str) -> &'static str {
-    match profile {
-        DEFAULT_PROFILE => "settings.json",
-        PROFILE1 => "settings-ccg-profile1.json",
-        PROFILE2 => "settings-ccg-profile2.json",
-        PROFILE3 => "settings-ccg-profile3.json",
-        _ => "settings.json",
+pub fn claude_settings_filename(profile: &str) -> String {
+    let profile = normalize_profile(Some(profile)).unwrap_or_else(|| DEFAULT_PROFILE.to_string());
+    if profile == DEFAULT_PROFILE {
+        "settings.json".to_string()
+    } else {
+        format!("settings-ccg-{}.json", profile)
     }
 }
 

--- a/src-tauri/src/commands/provider_commands.rs
+++ b/src-tauri/src/commands/provider_commands.rs
@@ -1,12 +1,363 @@
 use super::*;
 use crate::db::models::{
-    Provider, ProviderCreate, ProviderResponse, ProviderUpdate, TestProviderModelsInput,
+    Provider, ProviderCreate, ProviderProfileCreate, ProviderProfileRename,
+    ProviderProfileResponse, ProviderResponse, ProviderUpdate, TestProviderModelsInput,
 };
 use crate::time::now_timestamp;
 use crate::LogDb;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 use tauri::{Emitter, State};
+
+async fn unique_profile_name(
+    db: &SqlitePool,
+    cli_type: &str,
+    requested_name: &str,
+    current_name: Option<&str>,
+) -> Result<String> {
+    let base = normalize_profile_name(requested_name).ok_or_else(invalid_profile_message)?;
+    if current_name == Some(base.as_str()) {
+        return Ok(base);
+    }
+
+    let exists = base == DEFAULT_PROFILE
+        || sqlx::query_as::<_, (String,)>(
+            "SELECT name FROM provider_profiles WHERE cli_type = ? AND name = ?",
+        )
+        .bind(cli_type)
+        .bind(&base)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| e.to_string())?
+        .is_some();
+
+    if exists {
+        return Err("名称已存在".to_string());
+    }
+
+    Ok(base)
+}
+
+fn provider_profile_response(cli_type: String, name: String, sort_order: i64) -> ProviderProfileResponse {
+    let is_default = name == DEFAULT_PROFILE;
+    ProviderProfileResponse {
+        cli_type,
+        label: if is_default {
+            "默认".to_string()
+        } else {
+            name.clone()
+        },
+        name,
+        is_default,
+        sort_order,
+    }
+}
+
+async fn remove_profile_config_files(db: &SqlitePool, cli_type: &str, profile: &str) -> Result<()> {
+    if profile == DEFAULT_PROFILE {
+        return Ok(());
+    }
+
+    match cli_type {
+        "claude_code" => {
+            let claude_dir = get_cli_config_dir_path(db, "claude_code").await;
+            let claude_path = claude_dir.join(cli_helpers::claude_settings_filename(profile));
+            if tokio::fs::try_exists(&claude_path).await.unwrap_or(false) {
+                tokio::fs::remove_file(&claude_path)
+                    .await
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+        "codex" => {
+            let codex_dir = get_cli_config_dir_path(db, "codex").await;
+            let codex_path = codex_profile_config_path(&codex_dir, profile);
+            if tokio::fs::try_exists(&codex_path).await.unwrap_or(false) {
+                tokio::fs::remove_file(&codex_path)
+                    .await
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+async fn rename_profile_config_files(db: &SqlitePool, cli_type: &str, old_profile: &str, new_profile: &str) -> Result<()> {
+    if old_profile == DEFAULT_PROFILE || new_profile == DEFAULT_PROFILE {
+        return Ok(());
+    }
+
+    match cli_type {
+        "claude_code" => {
+            let claude_dir = get_cli_config_dir_path(db, "claude_code").await;
+            let old_claude = claude_dir.join(cli_helpers::claude_settings_filename(old_profile));
+            let new_claude = claude_dir.join(cli_helpers::claude_settings_filename(new_profile));
+            if tokio::fs::try_exists(&old_claude).await.unwrap_or(false)
+                && !tokio::fs::try_exists(&new_claude).await.unwrap_or(false)
+            {
+                tokio::fs::rename(&old_claude, &new_claude)
+                    .await
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+        "codex" => {
+            let codex_dir = get_cli_config_dir_path(db, "codex").await;
+            let old_codex = codex_profile_config_path(&codex_dir, old_profile);
+            let new_codex = codex_profile_config_path(&codex_dir, new_profile);
+            if tokio::fs::try_exists(&old_codex).await.unwrap_or(false)
+                && !tokio::fs::try_exists(&new_codex).await.unwrap_or(false)
+            {
+                tokio::fs::rename(&old_codex, &new_codex)
+                    .await
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+async fn rewrite_tasks_profile(db: &SqlitePool, cli_type: &str, old_profile: &str, new_profile: &str) -> Result<()> {
+    let rows: Vec<(i64, String)> = sqlx::query_as(
+        "SELECT id, payload_json FROM scheduled_tasks WHERE task_type = 'provider_keepalive'",
+    )
+    .fetch_all(db)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    for (id, payload_json) in rows {
+        let Ok(mut payload) = serde_json::from_str::<serde_json::Value>(&payload_json) else {
+            continue;
+        };
+        if payload
+            .get("profile")
+            .and_then(|value| value.as_str())
+            .map(|profile| profile == old_profile)
+            .unwrap_or(false)
+            && payload
+                .get("cli_type")
+                .and_then(|value| value.as_str())
+                .map(|task_cli_type| task_cli_type == cli_type)
+                .unwrap_or(false)
+        {
+            payload["profile"] = serde_json::Value::String(new_profile.to_string());
+            sqlx::query("UPDATE scheduled_tasks SET payload_json = ?, updated_at = ? WHERE id = ?")
+                .bind(payload.to_string())
+                .bind(now_timestamp())
+                .bind(id)
+                .execute(db)
+                .await
+                .map_err(map_db_error)?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn delete_tasks_for_profile(db: &SqlitePool, cli_type: &str, profile: &str) -> Result<()> {
+    let rows: Vec<(i64, String)> = sqlx::query_as(
+        "SELECT id, payload_json FROM scheduled_tasks WHERE task_type = 'provider_keepalive'",
+    )
+    .fetch_all(db)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    for (id, payload_json) in rows {
+        let delete_task = serde_json::from_str::<serde_json::Value>(&payload_json)
+            .ok()
+            .map(|payload| {
+                payload
+                    .get("profile")
+                    .and_then(|value| value.as_str())
+                    .map(|task_profile| task_profile == profile)
+                    .unwrap_or(false)
+                    && payload
+                        .get("cli_type")
+                        .and_then(|value| value.as_str())
+                        .map(|task_cli_type| task_cli_type == cli_type)
+                        .unwrap_or(false)
+            })
+            .unwrap_or(false);
+
+        if delete_task {
+            sqlx::query("DELETE FROM scheduled_tasks WHERE id = ?")
+                .bind(id)
+                .execute(db)
+                .await
+                .map_err(map_db_error)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_provider_profiles(db: State<'_, SqlitePool>, cli_type: String) -> Result<Vec<ProviderProfileResponse>> {
+    ensure_legacy_provider_profiles(db.inner()).await?;
+    let rows: Vec<(String, i64)> =
+        sqlx::query_as("SELECT name, sort_order FROM provider_profiles WHERE cli_type = ? ORDER BY sort_order, created_at, name")
+            .bind(&cli_type)
+            .fetch_all(db.inner())
+            .await
+            .map_err(|e| e.to_string())?;
+
+    let mut profiles = vec![provider_profile_response(cli_type.clone(), DEFAULT_PROFILE.to_string(), 0)];
+    profiles.extend(rows.into_iter().map(|(name, sort_order)| provider_profile_response(cli_type.clone(), name, sort_order)));
+    Ok(profiles)
+}
+
+#[tauri::command]
+pub async fn create_provider_profile(
+    db: State<'_, SqlitePool>,
+    input: ProviderProfileCreate,
+) -> Result<ProviderProfileResponse> {
+    let cli_type = input.cli_type.trim().to_string();
+    let name = unique_profile_name(db.inner(), &cli_type, &input.name, None).await?;
+
+    let now = now_timestamp();
+    let result = sqlx::query(
+        r#"
+        INSERT INTO provider_profiles (cli_type, name, sort_order, created_at, updated_at)
+        VALUES (?, ?, (SELECT COALESCE(MAX(sort_order), 0) + 10 FROM provider_profiles WHERE cli_type = ?), ?, ?)
+        "#,
+    )
+    .bind(&cli_type)
+    .bind(&name)
+    .bind(&cli_type)
+    .bind(now)
+    .bind(now)
+    .execute(db.inner())
+    .await
+    .map_err(map_db_error)?;
+
+    if result.rows_affected() == 0 {
+        return Err("Profile 创建失败".to_string());
+    }
+
+    let (sort_order,): (i64,) = sqlx::query_as("SELECT sort_order FROM provider_profiles WHERE cli_type = ? AND name = ?")
+        .bind(&cli_type)
+        .bind(&name)
+        .fetch_one(db.inner())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(provider_profile_response(cli_type, name, sort_order))
+}
+
+#[tauri::command]
+pub async fn rename_provider_profile(
+    db: State<'_, SqlitePool>,
+    profile: String,
+    input: ProviderProfileRename,
+) -> Result<ProviderProfileResponse> {
+    let cli_type = input.cli_type.trim().to_string();
+    let old_profile = validate_provider_profile(Some(&profile))?;
+    let new_profile =
+        unique_profile_name(db.inner(), &cli_type, &input.name, Some(&old_profile)).await?;
+    if old_profile == DEFAULT_PROFILE {
+        return Err("默认 Profile 不能重命名".to_string());
+    }
+    if old_profile == new_profile {
+        let (sort_order,): (i64,) = sqlx::query_as("SELECT sort_order FROM provider_profiles WHERE cli_type = ? AND name = ?")
+            .bind(&cli_type)
+            .bind(&old_profile)
+            .fetch_optional(db.inner())
+            .await
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| "Profile 不存在".to_string())?;
+        return Ok(provider_profile_response(cli_type, new_profile, sort_order));
+    }
+
+    let (sort_order,): (i64,) = sqlx::query_as("SELECT sort_order FROM provider_profiles WHERE cli_type = ? AND name = ?")
+        .bind(&cli_type)
+        .bind(&old_profile)
+        .fetch_optional(db.inner())
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "Profile 不存在".to_string())?;
+
+    let mut tx = db.inner().begin().await.map_err(|e| e.to_string())?;
+    sqlx::query("UPDATE provider_profiles SET name = ?, updated_at = ? WHERE cli_type = ? AND name = ?")
+        .bind(&new_profile)
+        .bind(now_timestamp())
+        .bind(&cli_type)
+        .bind(&old_profile)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_error)?;
+    sqlx::query("UPDATE providers SET profile = ?, updated_at = ? WHERE cli_type = ? AND profile = ?")
+        .bind(&new_profile)
+        .bind(now_timestamp())
+        .bind(&cli_type)
+        .bind(&old_profile)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_error)?;
+    tx.commit().await.map_err(|e| e.to_string())?;
+
+    rewrite_tasks_profile(db.inner(), &cli_type, &old_profile, &new_profile).await?;
+    rename_profile_config_files(db.inner(), &cli_type, &old_profile, &new_profile).await?;
+
+    Ok(provider_profile_response(cli_type, new_profile, sort_order))
+}
+
+#[tauri::command]
+pub async fn delete_provider_profile(db: State<'_, SqlitePool>, cli_type: String, profile: String) -> Result<()> {
+    let cli_type = cli_type.trim().to_string();
+    let profile = validate_provider_profile(Some(&profile))?;
+    if profile == DEFAULT_PROFILE {
+        return Err("默认 Profile 不能删除".to_string());
+    }
+
+    let exists: Option<(String,)> = sqlx::query_as("SELECT name FROM provider_profiles WHERE cli_type = ? AND name = ?")
+        .bind(&cli_type)
+        .bind(&profile)
+        .fetch_optional(db.inner())
+        .await
+        .map_err(|e| e.to_string())?;
+    if exists.is_none() {
+        return Err("Profile 不存在".to_string());
+    }
+
+    delete_tasks_for_profile(db.inner(), &cli_type, &profile).await?;
+
+    let provider_ids: Vec<(i64,)> = sqlx::query_as("SELECT id FROM providers WHERE cli_type = ? AND profile = ?")
+        .bind(&cli_type)
+        .bind(&profile)
+        .fetch_all(db.inner())
+        .await
+        .map_err(|e| e.to_string())?;
+    for (id,) in provider_ids {
+        sqlx::query("DELETE FROM provider_model_map WHERE provider_id = ?")
+            .bind(id)
+            .execute(db.inner())
+            .await
+            .map_err(map_db_error)?;
+        sqlx::query("DELETE FROM provider_model_blacklist WHERE provider_id = ?")
+            .bind(id)
+            .execute(db.inner())
+            .await
+            .map_err(map_db_error)?;
+    }
+
+    sqlx::query("DELETE FROM providers WHERE cli_type = ? AND profile = ?")
+        .bind(&cli_type)
+        .bind(&profile)
+        .execute(db.inner())
+        .await
+        .map_err(map_db_error)?;
+    sqlx::query("DELETE FROM provider_profiles WHERE cli_type = ? AND name = ?")
+        .bind(&cli_type)
+        .bind(&profile)
+        .execute(db.inner())
+        .await
+        .map_err(map_db_error)?;
+
+    remove_profile_config_files(db.inner(), &cli_type, &profile).await?;
+    Ok(())
+}
 
 fn normalize_price_per_m(value: Option<f64>, field: &str) -> Result<f64> {
     let value = value.unwrap_or(0.0);

--- a/src-tauri/src/commands/settings_commands.rs
+++ b/src-tauri/src/commands/settings_commands.rs
@@ -192,7 +192,8 @@ pub async fn ensure_claude_profile_settings(
 
     let config_dir = get_cli_config_dir_path(db.inner(), "claude_code").await;
     let config_path = config_dir.join(cli_helpers::claude_settings_filename(&profile));
-    let gateway_token = gateway_token_for_profile(&profile).unwrap_or("ccg-gateway");
+    let gateway_token =
+        gateway_token_for_profile(&profile).unwrap_or_else(|| "ccg-gateway".to_string());
     let use_merge = get_config_write_mode(db.inner(), "claude_code").await == "merge";
 
     write_claude_gateway_settings(
@@ -201,7 +202,7 @@ pub async fn ensure_claude_profile_settings(
         None,
         use_merge,
         &gateway_url,
-        gateway_token,
+        &gateway_token,
     )
     .await?;
 
@@ -302,12 +303,12 @@ pub async fn ensure_codex_profile_settings(
 
 async fn collect_provider_direct_rewrite_ids(db: &SqlitePool, cli_type: &str) -> Result<Vec<i64>> {
     let mut ids = Vec::new();
-    for profile in PROVIDER_PROFILES {
+    for profile in list_provider_profile_names(db).await? {
         if cli_type == "gemini" && profile != DEFAULT_PROFILE {
             continue;
         }
 
-        if let Some(id) = provider_direct_active_provider_id(db, cli_type, profile).await? {
+        if let Some(id) = provider_direct_active_provider_id(db, cli_type, &profile).await? {
             if !ids.contains(&id) {
                 ids.push(id);
             }

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -6,6 +6,36 @@ use crate::time::now_timestamp;
 // ==================== Provider 相关实体 ====================
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct ProviderProfile {
+    pub cli_type: String,
+    pub name: String,
+    pub sort_order: i64,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderProfileResponse {
+    pub cli_type: String,
+    pub name: String,
+    pub label: String,
+    pub is_default: bool,
+    pub sort_order: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderProfileCreate {
+    pub cli_type: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderProfileRename {
+    pub cli_type: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct Provider {
     pub id: i64,
     pub cli_type: String,

--- a/src-tauri/src/db/schema_definition.rs
+++ b/src-tauri/src/db/schema_definition.rs
@@ -97,7 +97,7 @@ impl DatabaseSchema {
     /// 获取当前主数据库 Schema
     pub fn current() -> Self {
         Self {
-            version: 29,
+            version: 30,
             tables: Self::define_main_tables(),
             indexes: Vec::new(),
         }
@@ -254,6 +254,48 @@ impl DatabaseSchema {
                     "profile".to_string(),
                     "name".to_string(),
                 ]],
+            },
+        );
+
+        // provider_profiles 表
+        tables.insert(
+            "provider_profiles".to_string(),
+            TableDefinition {
+                name: "provider_profiles".to_string(),
+                columns: vec![
+                    ColumnDefinition {
+                        name: "cli_type".to_string(),
+                        data_type: "TEXT".to_string(),
+                        nullable: false,
+                        default_value: Some("'claude_code'".to_string()),
+                    },
+                    ColumnDefinition {
+                        name: "name".to_string(),
+                        data_type: "TEXT".to_string(),
+                        nullable: false,
+                        default_value: None,
+                    },
+                    ColumnDefinition {
+                        name: "sort_order".to_string(),
+                        data_type: "INTEGER".to_string(),
+                        nullable: false,
+                        default_value: Some("0".to_string()),
+                    },
+                    ColumnDefinition {
+                        name: "created_at".to_string(),
+                        data_type: "INTEGER".to_string(),
+                        nullable: false,
+                        default_value: None,
+                    },
+                    ColumnDefinition {
+                        name: "updated_at".to_string(),
+                        data_type: "INTEGER".to_string(),
+                        nullable: false,
+                        default_value: None,
+                    },
+                ],
+                primary_key: vec!["cli_type".to_string(), "name".to_string()],
+                unique_constraints: vec![],
             },
         );
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -356,6 +356,10 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             commands::provider_commands::get_providers,
+            commands::provider_commands::get_provider_profiles,
+            commands::provider_commands::create_provider_profile,
+            commands::provider_commands::rename_provider_profile,
+            commands::provider_commands::delete_provider_profile,
             commands::provider_commands::get_provider,
             commands::provider_commands::create_provider,
             commands::provider_commands::update_provider,

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -236,7 +236,7 @@ fn bearer_token(value: &str) -> &str {
 }
 
 /// Detect provider profile from the gateway token sent by the CLI.
-pub fn detect_gateway_profile(headers: &HeaderMap) -> &'static str {
+pub fn detect_gateway_profile(headers: &HeaderMap) -> String {
     let header_names = ["authorization", "x-api-key", "x-goog-api-key"];
 
     for name in header_names {
@@ -247,7 +247,7 @@ pub fn detect_gateway_profile(headers: &HeaderMap) -> &'static str {
         }
     }
 
-    DEFAULT_PROFILE
+    DEFAULT_PROFILE.to_string()
 }
 
 /// Check if request is streaming based on body content

--- a/src-tauri/src/services/routing.rs
+++ b/src-tauri/src/services/routing.rs
@@ -6,55 +6,71 @@ use crate::services::proxy::wildcard_match;
 use crate::time::now_timestamp;
 
 pub const DEFAULT_PROFILE: &str = "default";
-pub const PROFILE1: &str = "profile1";
-pub const PROFILE2: &str = "profile2";
-pub const PROFILE3: &str = "profile3";
-
-pub const PROVIDER_PROFILES: [&str; 4] = [DEFAULT_PROFILE, PROFILE1, PROFILE2, PROFILE3];
 pub const GATEWAY_PROFILE_PATH_ROOT: &str = "/__ccg";
 
-pub fn normalize_profile(profile: Option<&str>) -> Option<&'static str> {
+pub fn normalize_profile(profile: Option<&str>) -> Option<String> {
     let profile = profile.unwrap_or(DEFAULT_PROFILE).trim();
-    match profile {
-        "" | DEFAULT_PROFILE => Some(DEFAULT_PROFILE),
-        PROFILE1 => Some(PROFILE1),
-        PROFILE2 => Some(PROFILE2),
-        PROFILE3 => Some(PROFILE3),
-        _ => None,
+    if profile.is_empty() || profile.eq_ignore_ascii_case(DEFAULT_PROFILE) {
+        return Some(DEFAULT_PROFILE.to_string());
+    }
+
+    normalize_profile_name(profile)
+}
+
+pub fn normalize_profile_name(profile: &str) -> Option<String> {
+    let profile = profile.trim();
+    if profile.is_empty() {
+        return None;
+    }
+
+    let profile = profile
+        .split_whitespace()
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("_");
+    is_valid_profile_name(&profile).then_some(profile)
+}
+
+pub fn is_valid_profile_name(profile: &str) -> bool {
+    let profile = profile.trim();
+    !profile.is_empty()
+        && profile.len() <= 64
+        && profile != "."
+        && profile != ".."
+        && profile
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+}
+
+pub fn gateway_token_for_profile(profile: &str) -> Option<String> {
+    let profile = normalize_profile(Some(profile))?;
+    if profile == DEFAULT_PROFILE {
+        Some("ccg-gateway".to_string())
+    } else {
+        Some(format!("ccg-gateway-{}", profile))
     }
 }
 
-pub fn gateway_token_for_profile(profile: &str) -> Option<&'static str> {
-    match normalize_profile(Some(profile))? {
-        DEFAULT_PROFILE => Some("ccg-gateway"),
-        PROFILE1 => Some("ccg-gateway-1"),
-        PROFILE2 => Some("ccg-gateway-2"),
-        PROFILE3 => Some("ccg-gateway-3"),
-        _ => None,
+pub fn profile_from_gateway_token(token: &str) -> Option<String> {
+    let token = token.trim();
+    if token == "ccg-gateway" {
+        return Some(DEFAULT_PROFILE.to_string());
+    }
+
+    let profile = token.strip_prefix("ccg-gateway-")?;
+    normalize_profile(Some(profile))
+}
+
+pub fn gateway_path_prefix_for_profile(profile: &str) -> Option<String> {
+    let profile = normalize_profile(Some(profile))?;
+    if profile == DEFAULT_PROFILE {
+        Some(String::new())
+    } else {
+        Some(format!("{}/{}", GATEWAY_PROFILE_PATH_ROOT, profile))
     }
 }
 
-pub fn profile_from_gateway_token(token: &str) -> Option<&'static str> {
-    match token.trim() {
-        "ccg-gateway" => Some(DEFAULT_PROFILE),
-        "ccg-gateway-1" => Some(PROFILE1),
-        "ccg-gateway-2" => Some(PROFILE2),
-        "ccg-gateway-3" => Some(PROFILE3),
-        _ => None,
-    }
-}
-
-pub fn gateway_path_prefix_for_profile(profile: &str) -> Option<&'static str> {
-    match normalize_profile(Some(profile))? {
-        DEFAULT_PROFILE => Some(""),
-        PROFILE1 => Some("/__ccg/profile1"),
-        PROFILE2 => Some("/__ccg/profile2"),
-        PROFILE3 => Some("/__ccg/profile3"),
-        _ => None,
-    }
-}
-
-pub fn split_gateway_profile_path(full_path: &str) -> Option<(&'static str, String)> {
+pub fn split_gateway_profile_path(full_path: &str) -> Option<(String, String)> {
     let rest = full_path.strip_prefix("/__ccg/")?;
     let (profile_segment, suffix) = match rest.find(|c| c == '/' || c == '?') {
         Some(index) => (&rest[..index], &rest[index..]),
@@ -152,7 +168,7 @@ pub async fn select_provider(
     model: Option<&str>,
 ) -> Result<Option<ProviderWithMaps>, sqlx::Error> {
     let now = now_timestamp();
-    let profile = normalize_profile(Some(profile)).unwrap_or(DEFAULT_PROFILE);
+    let profile = normalize_profile(Some(profile)).unwrap_or_else(|| DEFAULT_PROFILE.to_string());
 
     // Query enabled providers ordered by sort_order, excluding blacklisted ones
     let providers = sqlx::query_as::<_, Provider>(
@@ -166,7 +182,7 @@ pub async fn select_provider(
         "#,
     )
     .bind(cli_type)
-    .bind(profile)
+    .bind(&profile)
     .bind(now)
     .fetch_all(db)
     .await?;
@@ -207,7 +223,7 @@ pub async fn get_available_providers(
     model: Option<&str>,
 ) -> Result<Vec<ProviderWithMaps>, sqlx::Error> {
     let now = now_timestamp();
-    let profile = normalize_profile(Some(profile)).unwrap_or(DEFAULT_PROFILE);
+    let profile = normalize_profile(Some(profile)).unwrap_or_else(|| DEFAULT_PROFILE.to_string());
 
     let providers = sqlx::query_as::<_, Provider>(
         r#"
@@ -220,7 +236,7 @@ pub async fn get_available_providers(
         "#,
     )
     .bind(cli_type)
-    .bind(profile)
+    .bind(&profile)
     .bind(now)
     .fetch_all(db)
     .await?;

--- a/src-tauri/src/services/scheduler.rs
+++ b/src-tauri/src/services/scheduler.rs
@@ -783,7 +783,8 @@ async fn resolve_keepalive_targets(
                 .cli_type
                 .as_deref()
                 .ok_or_else(|| "全选模式缺少 cli_type".to_string())?;
-            let profile = normalize_profile(payload.profile.as_deref()).unwrap_or(DEFAULT_PROFILE);
+            let profile = normalize_profile(payload.profile.as_deref())
+                .unwrap_or_else(|| DEFAULT_PROFILE.to_string());
 
             let providers = sqlx::query_as::<_, Provider>(
                 r#"
@@ -793,7 +794,7 @@ async fn resolve_keepalive_targets(
                 "#,
             )
             .bind(cli_type)
-            .bind(profile)
+            .bind(&profile)
             .fetch_all(db)
             .await
             .map_err(|e| e.to_string())?;


### PR DESCRIPTION
## 变更说明

将服务商页固定的 Profile 1~3 改为按 CLI 类型动态管理的 Profile。默认只保留“默认”，用户可以在服务商页直接新增、重命名和删除 Profile，并同步清理对应配置与数据库记录。

## 主要改动

- 新增 provider_profiles 表，按 cli_type 独立记录 Profile 名称、排序和时间信息
- 服务商页 Profile 标签改为动态加载，支持点击加号直接创建并进入重命名状态
- 支持 Profile 重命名、删除和重排相关数据同步，删除当前 Profile 后切到左侧 Profile
- Profile 名称限制为英文、数字、空格、下划线和短横线，保存时将空格规范化为下划线
- Codex 与 Claude Code Profile 分开管理，生成对应 Profile 配置文件与启动命令
- 定时任务等引用 Profile 的页面改为读取动态 Profile 列表
- 数据库 schema 升级到 30，并迁移旧版 profile1/profile2/profile3 中已有服务商