### PR TITLE
feat: 根据请求路径/协议类型识别 Agent 类型

### DIFF
--- a/src-tauri/src/api/handlers.rs
+++ b/src-tauri/src/api/handlers.rs
@@ -59,8 +59,14 @@ pub async fn proxy_handler_catchall(
             (None, raw_full_path.clone())
         };
 
-    // Detect CLI type from User-Agent
-    let cli_type = detect_cli_type(&headers);
+    // Detect CLI type from request path / protocol type
+    let cli_type = match detect_cli_type(&full_path) {
+        Some(t) => t,
+        None => {
+            tracing::error!(path = %full_path, "Unknown request protocol / path");
+            return Err(StatusCode::BAD_REQUEST);
+        }
+    };
     let provider_profile = path_profile.unwrap_or_else(|| detect_gateway_profile(&headers));
 
     // Serialize client headers for logging

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -207,20 +207,18 @@ pub struct TokenUsage {
     gemini_thoughts_token_count: i64,
 }
 
-/// Detect CLI type from User-Agent header
-pub fn detect_cli_type(headers: &HeaderMap) -> CliType {
-    let ua = headers
-        .get("user-agent")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("")
-        .to_lowercase();
+/// Detect CLI type from request path / protocol type
+pub fn detect_cli_type(path: &str) -> Option<CliType> {
+    let path_lower = path.to_lowercase();
 
-    if ua.contains("codex") || ua.contains("openai") {
-        CliType::Codex
-    } else if ua.contains("gemini") || ua.contains("google") {
-        CliType::Gemini
+    if path_lower == "/responses" || path_lower == "/chat/completions" {
+        Some(CliType::Codex)
+    } else if path_lower == "/messages" {
+        Some(CliType::ClaudeCode)
+    } else if path_lower.contains("generatecontent") {
+        Some(CliType::Gemini)
     } else {
-        CliType::ClaudeCode
+        None
     }
 }
 


### PR DESCRIPTION
目前网关主要是通过请求头中的 User-Agent 来识别 CLI 类型的，这导致像 opencode 等使用自定义/其他 User-Agent 的第三方客户端在接入网关时会被默认识别为 ClaudeCode，进而引发 Token 和 Cache 数量解析错误。

本 PR 修改了识别逻辑：
1. 优先通过请求路径和协议类型来识别 Agent 类型（例如 `/responses` 或 `/chat/completions` 归为 `Codex`，`/messages` 归为 `ClaudeCode`，`generateContent` 归为 `Gemini`）。
2. 如果没有任何特征路径匹配，网关会直接返回 400 Bad Request 报错，并在控制台输出 Unknown request protocol。
3. 此修改允许了 `opencode` 等第三方 OpenAI 协议兼容客户端在不强制修改 User-Agent 的情况下直接连接并正常统计 Token 计量。