### PR TITLE
feat: 根据请求路径/协议类型识别 Agent 类型

### DIFF
--- a/src-tauri/src/api/handlers.rs
+++ b/src-tauri/src/api/handlers.rs
@@ -59,8 +59,14 @@ pub async fn proxy_handler_catchall(
             (None, raw_full_path.clone())
         };
 
-    // Detect CLI type from User-Agent
-    let cli_type = detect_cli_type(&headers);
+    // Detect CLI type from request path / protocol type
+    let cli_type = match detect_cli_type(&full_path) {
+        Some(t) => t,
+        None => {
+            tracing::error!(path = %full_path, "Unknown request protocol / path");
+            return Err(StatusCode::BAD_REQUEST);
+        }
+    };
     let provider_profile = path_profile.unwrap_or_else(|| detect_gateway_profile(&headers));
 
     // Serialize client headers for logging

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -207,20 +207,18 @@ pub struct TokenUsage {
     gemini_thoughts_token_count: i64,
 }
 
-/// Detect CLI type from User-Agent header
-pub fn detect_cli_type(headers: &HeaderMap) -> CliType {
-    let ua = headers
-        .get("user-agent")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("")
-        .to_lowercase();
+/// Detect CLI type from request path / protocol type
+pub fn detect_cli_type(path: &str) -> Option<CliType> {
+    let path_lower = path.to_lowercase();
 
-    if ua.contains("codex") || ua.contains("openai") {
-        CliType::Codex
-    } else if ua.contains("gemini") || ua.contains("google") {
-        CliType::Gemini
+    if path_lower.contains("responses") || path_lower.contains("chat/completions") {
+        Some(CliType::Codex)
+    } else if path_lower.contains("messages") {
+        Some(CliType::ClaudeCode)
+    } else if path_lower.contains("generatecontent") {
+        Some(CliType::Gemini)
     } else {
-        CliType::ClaudeCode
+        None
     }
 }
 


### PR DESCRIPTION
之前 #19 没考虑到Claude Code请求的地址是`v1`开头的，这次使用`contains`，应该不会有什么问题了。
还有，目前的逻辑有点奇怪，Claude Code是请求的带`v1`，转发也带`v1`，Codex是请求不带`v1`，转发带`v1`，要不要统一下，让Codex的请求地址也带`v1`？不过这样就是个Breaking changes了。